### PR TITLE
bugfix:zipkin plugin not set tracing data to request header.

### DIFF
--- a/lua/apisix/plugins/zipkin.lua
+++ b/lua/apisix/plugins/zipkin.lua
@@ -122,7 +122,7 @@ function _M.access(conf, ctx)
     local outgoing_headers = {}
     tracer:inject(opentracing.proxy_span, "http_headers", outgoing_headers)
     for k, v in pairs(outgoing_headers) do
-        core.response.set_header(k, v)
+        core.request.set_header(k, v)
     end
 end
 


### PR DESCRIPTION
fixed:[#713 ](https://github.com/iresty/apisix/pull/713)