### PR TITLE
delete admin routes.lua host and hosts variable duplicate check code

### DIFF
--- a/lua/apisix/admin/routes.lua
+++ b/lua/apisix/admin/routes.lua
@@ -59,10 +59,6 @@ local function check_conf(id, conf, need_id)
                                  .. "allowed"}
     end
 
-    if conf.host and conf.hosts then
-        return nil, {error_msg = "only one of host or hosts is allowed"}
-    end
-
     local upstream_id = conf.upstream_id
     if upstream_id then
         local key = "/upstreams/" .. upstream_id


### PR DESCRIPTION

Fix #delete admin routes.lua host and hosts variable duplicate check code
