### PR TITLE
change: don't strip square brackets from the IPv6

### DIFF
--- a/lua/apisix/core/utils.lua
+++ b/lua/apisix/core/utils.lua
@@ -96,8 +96,8 @@ end
 
 -- parse_addr parses 'addr' into the host and the port parts. If the 'addr'
 -- doesn't have a port, 80 is used to return. For malformed 'addr', the entire
--- 'addr' is returned as the host part. For IPv6 literal host, like [::1], the
--- square brackets will be removed.
+-- 'addr' is returned as the host part. For IPv6 literal host, like [::1],
+-- the square brackets will be kept.
 function _M.parse_addr(addr)
     local default_port = 80
     if str_byte(addr, 1) == str_byte("[") then
@@ -106,7 +106,7 @@ function _M.parse_addr(addr)
         local len = #addr
         if str_byte(addr, len) == right_bracket then
             -- addr in [ip:v6] format
-            return sub_str(addr, 2, len-1), default_port
+            return sub_str(addr, 1, len), default_port
         else
             local pos = rfind_char(addr, ":", #addr - 1)
             if not pos or str_byte(addr, pos - 1) ~= right_bracket then
@@ -115,7 +115,7 @@ function _M.parse_addr(addr)
             end
 
             -- addr in [ip:v6]:port format
-            local host = sub_str(addr, 2, pos - 2)
+            local host = sub_str(addr, 1, pos - 1)
             local port = sub_str(addr, pos + 1)
             return host, tonumber(port)
         end

--- a/lua/apisix/core/utils.lua
+++ b/lua/apisix/core/utils.lua
@@ -106,7 +106,7 @@ function _M.parse_addr(addr)
         local len = #addr
         if str_byte(addr, len) == right_bracket then
             -- addr in [ip:v6] format
-            return sub_str(addr, 1, len), default_port
+            return addr, default_port
         else
             local pos = rfind_char(addr, ":", #addr - 1)
             if not pos or str_byte(addr, pos - 1) ~= right_bracket then

--- a/rockspec/apisix-master-0.rockspec
+++ b/rockspec/apisix-master-0.rockspec
@@ -48,6 +48,7 @@ dependencies = {
     "lua-tinyyaml = 0.1",
     "iresty-nginx-lua-prometheus = 0.20190917",
     "jsonschema = 0.4",
+    "lua-resty-ipmatcher = 0.3",
 }
 
 build = {

--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -170,7 +170,15 @@ _EOC_
         listen 1980;
         listen 1981;
         listen 1982;
+_EOC_
 
+    my $ipv6_fake_server = "";
+    if (defined $block->listen_ipv6) {
+        $ipv6_fake_server = "listen \[::1\]:1980;";
+    }
+
+    $http_config .= <<_EOC_;
+        $ipv6_fake_server
         server_tokens off;
 
         location / {

--- a/t/core/utils.t
+++ b/t/core/utils.t
@@ -53,9 +53,9 @@ qr/random seed \d+\ntwice: false/
                 {addr = "www.test.com", host = "www.test.com", port = 80},
                 {addr = "www.test.com:90", host = "www.test.com", port = 90},
                 {addr = "[127.0.0.1:90", host = "[127.0.0.1:90", port = 80},
-                {addr = "[::1]", host = "::1", port = 80},
-                {addr = "[::1]:1234", host = "::1", port = 1234},
-                {addr = "[::1234:1234]:12345", host = "::1234:1234", port = 12345},
+                {addr = "[::1]", host = "[::1]", port = 80},
+                {addr = "[::1]:1234", host = "[::1]", port = 1234},
+                {addr = "[::1234:1234]:12345", host = "[::1234:1234]", port = 12345},
             }
             for _, case in ipairs(cases) do
                 local host, port = parse_addr(case.addr)
@@ -66,3 +66,5 @@ qr/random seed \d+\ntwice: false/
     }
 --- request
 GET /t
+--- no_error_log
+[error]

--- a/t/node/healthcheck-ipv6.t
+++ b/t/node/healthcheck-ipv6.t
@@ -1,0 +1,154 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+BEGIN {
+    if ($ENV{TEST_NGINX_CHECK_LEAK}) {
+        $SkipReason = "unavailable for the hup tests";
+
+    } else {
+        $ENV{TEST_NGINX_USE_HUP} = 1;
+        undef $ENV{TEST_NGINX_USE_STAP};
+    }
+}
+
+use t::APISIX;
+
+my $travis_os_name = $ENV{TRAVIS_OS_NAME};
+if ((defined $travis_os_name) && $travis_os_name eq "linux") {
+    plan(skip_all =>
+      "skip under Travis CI inux environment which doesn't work well with IPv6");
+} else {
+    plan 'no_plan';
+}
+
+master_on();
+repeat_each(1);
+log_level('info');
+no_root_location();
+no_shuffle();
+worker_connections(256);
+
+add_block_preprocessor(sub {
+    my $block = shift;
+    $block->set_value("listen_ipv6", 1);
+});
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: set route(two upstream node: one healthy + one unhealthy)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "uri": "/server_port",
+                    "upstream": {
+                        "type": "roundrobin",
+                        "nodes": {
+                            "127.0.0.1:1980": 1,
+                            "127.0.0.1:1970": 1
+                        },
+                        "checks": {
+                            "active": {
+                                "http_path": "/status",
+                                "host": "foo.com",
+                                "healthy": {
+                                    "interval": 1,
+                                    "successes": 1
+                                },
+                                "unhealthy": {
+                                    "interval": 1,
+                                    "http_failures": 1
+                                }
+                            }
+                        }
+                    }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- grep_error_log eval
+qr/^.*?\[error\](?!.*process exiting).*/
+--- grep_error_log_out
+
+
+
+=== TEST 2: hit routes (two upstream node: one healthy + one unhealthy)
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local uri = "http://127.0.0.1:" .. ngx.var.server_port
+                        .. "/server_port"
+
+            do
+                local httpc = http.new()
+                local res, err = httpc:request_uri(uri, {method = "GET", keepalive = false})
+                ngx.log(ngx.ERR, "It works")
+            end
+
+            ngx.sleep(2.5)
+
+            local ports_count = {}
+            for i = 1, 12 do
+                ngx.log(ngx.ERR, "req ", i)
+                local httpc = http.new()
+                local res, err = httpc:request_uri(uri, {method = "GET", keepalive = false})
+                if not res then
+                    ngx.say(err)
+                    return
+                end
+
+                ngx.log(ngx.ERR, "req ", i, " ", res.body)
+                ports_count[res.body] = (ports_count[res.body] or 0) + 1
+            end
+
+            local ports_arr = {}
+            for port, count in pairs(ports_count) do
+                table.insert(ports_arr, {port = port, count = count})
+            end
+
+            local function cmd(a, b)
+                return a.port > b.port
+            end
+            table.sort(ports_arr, cmd)
+
+            ngx.say(require("cjson").encode(ports_arr))
+            ngx.exit(200)
+        }
+    }
+--- request
+GET /t
+--- response_body
+[{"count":12,"port":"1980"}]
+--- grep_error_log eval
+qr/\[error\].*/
+--- grep_error_log_out eval
+qr/Connection refused\) while connecting to upstream/
+--- timeout: 10

--- a/t/node/upstream-ipv6.t
+++ b/t/node/upstream-ipv6.t
@@ -16,8 +16,6 @@
 #
 use t::APISIX;
 
-no_root_location();
-
 my $travis_os_name = $ENV{TRAVIS_OS_NAME};
 if ((defined $travis_os_name) && $travis_os_name eq "linux") {
     plan(skip_all =>
@@ -26,33 +24,40 @@ if ((defined $travis_os_name) && $travis_os_name eq "linux") {
     plan 'no_plan';
 }
 
+repeat_each(1);
+log_level('info');
+worker_connections(256);
+no_root_location();
+no_shuffle();
+
+add_block_preprocessor(sub {
+    my $block = shift;
+    $block->set_value("listen_ipv6", 1);
+});
+
 run_tests();
 
 __DATA__
 
-=== TEST 1: set route: remote addr = ::1
+=== TEST 1: set upstream(id: 1)
 --- config
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code, body = t('/apisix/admin/routes/1',
+            local code, body = t('/apisix/admin/upstreams/1',
                  ngx.HTTP_PUT,
                  [[{
-                        "remote_addr": "::1",
-                        "upstream": {
-                            "nodes": {
-                                "127.0.0.1:1980": 1
-                            },
-                            "type": "roundrobin"
-                        },
-                        "uri": "/hello"
+                    "nodes": {
+                        "[::1]:1980": 1
+                    },
+                    "type": "roundrobin",
+                    "desc": "new upstream"
                 }]]
                 )
 
             if code >= 300 then
                 ngx.status = code
             end
-
             ngx.say(body)
         }
     }
@@ -65,71 +70,49 @@ passed
 
 
 
-=== TEST 2: IPv6 /not_found
---- listen_ipv6
+=== TEST 2: set route(id: 1)
 --- config
-location /t {
-    content_by_lua_block {
-        ngx.sleep(0.2)
-        local t = require("lib.test_admin").test_ipv6
-        t('/not_found')
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "uri": "/hello",
+                        "upstream_id": "1"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
     }
-}
---- request
-GET /t
---- response_body_like eval
-qr{.*404 Not Found.*}
---- no_error_log
-[error]
-
-
-
-=== TEST 3: IPv4 /not_found
---- listen_ipv6
---- request
-GET /not_found
---- error_code: 404
---- response_body_like eval
-qr{.*404 Not Found.*}
---- no_error_log
-[error]
-
-
-
-=== TEST 4: IPv6 /hello
---- listen_ipv6
---- config
-location /t {
-    content_by_lua_block {
-        ngx.sleep(0.2)
-        local t = require("lib.test_admin").test_ipv6
-        t('/hello')
-    }
-}
 --- request
 GET /t
 --- response_body
-connected: 1
-request sent: 59
-received: HTTP/1.1 200 OK
-received: Content-Type: text/plain
-received: Connection: close
-received: Server: openresty
-received: 
-received: hello world
-failed to receive a line: closed []
-close: 1 nil
+passed
 --- no_error_log
 [error]
 
 
 
-=== TEST 5: IPv4 /hello
---- listen_ipv6
+=== TEST 3: /not_found
+--- request
+GET /not_found
+--- error_code: 404
+--- response_body eval
+qr/404 Not Found/
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: hit routes
 --- request
 GET /hello
---- error_code: 404
---- response_body_like eval
-qr{.*404 Not Found.*}
+--- response_body
+hello world
 --- no_error_log
 [error]


### PR DESCRIPTION
The OpenResty APIs require the IPv6 literal wrapped inside a square brackets.
Also add tests for IPv6 upstream and update lua-resty-ipmatcher to 0.3.

Fix #816.
