### PR TITLE
Allow APISIX config more Nginx-built-in directives into nginx.conf

### DIFF
--- a/bin/apisix
+++ b/bin/apisix
@@ -284,6 +284,12 @@ http {
         }
         {% end %}
 
+        {% if server then %}
+        {% for directive, directive_val in pairs(server) do %}
+        {*directive*} {*directive_val*};
+        {% end %}
+        {% end %}
+
         {% if enable_admin and not port_admin then %}
         location /apisix/admin {
             {%if allow_admin then%}

--- a/bin/apisix
+++ b/bin/apisix
@@ -260,7 +260,7 @@ http {
         {*directive*} {*directive_val*};
         {% end %}
         {% end %}
-            
+
         listen {* node_listen *};
         {% if ssl.enable then %}
         listen {* ssl.listen_port *} ssl {% if ssl.enable_http2 then %} http2 {% end %};

--- a/bin/apisix
+++ b/bin/apisix
@@ -255,6 +255,12 @@ http {
     {% end %}
 
     server {
+        {% if server then %}
+        {% for directive, directive_val in pairs(server) do %}
+        {*directive*} {*directive_val*};
+        {% end %}
+        {% end %}
+            
         listen {* node_listen *};
         {% if ssl.enable then %}
         listen {* ssl.listen_port *} ssl {% if ssl.enable_http2 then %} http2 {% end %};
@@ -282,12 +288,6 @@ http {
             access_log off;
             stub_status;
         }
-        {% end %}
-
-        {% if server then %}
-        {% for directive, directive_val in pairs(server) do %}
-        {*directive*} {*directive_val*};
-        {% end %}
         {% end %}
 
         {% if enable_admin and not port_admin then %}

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -65,11 +65,9 @@ nginx_config:                     # config for render the template to genarate n
     client_header_timeout: 60s     # timeout for reading client request header, then 408 (Request Time-out) error is returned to the client
     client_body_timeout: 60s       # timeout for reading client request body, then 408 (Request Time-out) error is returned to the client
     send_timeout: 10s              # timeout for transmitting a response to the client.then the connection is closed
-  client_body_buffer_size: 16k   # Sets buffer size for reading client request body
   #server:                          # set custusmized directives in nginx.conf server field, this is for HTTP server ONLY
-  #  server_tokens: on             # Enables emitting nginx version on error pages and in the "Server"
-  #  add_header: "API-Gateway-ID: '001'" # add custusmized header
-
+  #  client_body_buffer_size: 16k   # Sets buffer size for reading client request body
+ 
 etcd:
   host: "http://127.0.0.1:2379"   # etcd address
   prefix: "/apisix"               # apisix configurations prefix

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -65,11 +65,10 @@ nginx_config:                     # config for render the template to genarate n
     client_header_timeout: 60s     # timeout for reading client request header, then 408 (Request Time-out) error is returned to the client
     client_body_timeout: 60s       # timeout for reading client request body, then 408 (Request Time-out) error is returned to the client
     send_timeout: 10s              # timeout for transmitting a response to the client.then the connection is closed
-  server:                          # set custusmized directives in nginx.conf server field  
-    client_body_buffer_size: 16k   # Sets buffer size for reading client request body
+  client_body_buffer_size: 16k   # Sets buffer size for reading client request body
+  #server:                          # set custusmized directives in nginx.conf server field, this is for HTTP server ONLY
   #  server_tokens: on             # Enables emitting nginx version on error pages and in the "Server"
   #  add_header: "API-Gateway-ID: '001'" # add custusmized header
-  #  underscores_in_headers: on    # Enable the use of underscores in client request header fields
 
 etcd:
   host: "http://127.0.0.1:2379"   # etcd address

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -66,10 +66,10 @@ nginx_config:                     # config for render the template to genarate n
     client_body_timeout: 60s       # timeout for reading client request body, then 408 (Request Time-out) error is returned to the client
     send_timeout: 10s              # timeout for transmitting a response to the client.then the connection is closed
   server:                          # set custusmized directives in nginx.conf server field  
-    server_tokens: on              # Enables emitting nginx version on error pages and in the "Server"
-    add_header: "API-Gateway-ID: '001'" # add custusmized header
-    underscores_in_headers: off    # Disable the use of underscores in client request header fields
-    client_body_buffer_size: 64k  # Sets buffer size for reading client request body
+    client_body_buffer_size: 16k   # Sets buffer size for reading client request body
+  #  server_tokens: on             # Enables emitting nginx version on error pages and in the "Server"
+  #  add_header: "API-Gateway-ID: '001'" # add custusmized header
+  #  underscores_in_headers: on    # Enable the use of underscores in client request header fields
 
 etcd:
   host: "http://127.0.0.1:2379"   # etcd address

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -65,6 +65,11 @@ nginx_config:                     # config for render the template to genarate n
     client_header_timeout: 60s     # timeout for reading client request header, then 408 (Request Time-out) error is returned to the client
     client_body_timeout: 60s       # timeout for reading client request body, then 408 (Request Time-out) error is returned to the client
     send_timeout: 10s              # timeout for transmitting a response to the client.then the connection is closed
+  server:                          # set custusmized directives in nginx.conf server field  
+    server_tokens: on              # Enables emitting nginx version on error pages and in the "Server"
+    add_header: "API-Gateway-ID: '001'" # add custusmized header
+    underscores_in_headers: off    # Disable the use of underscores in client request header fields
+    client_body_buffer_size: 64k  # Sets buffer size for reading client request body
 
 etcd:
   host: "http://127.0.0.1:2379"   # etcd address


### PR DESCRIPTION
### Summary
 
allow user write custom directives configuration in server field into nginx.conf


### Full changelog

* bin/apisix

### Issues resolved

Fix https://github.com/apache/incubator-apisix/issues/854
