### PR TITLE
Resolve #882 and simplify conf

### DIFF
--- a/bin/apisix
+++ b/bin/apisix
@@ -234,14 +234,7 @@ http {
             }
         }
 
-        location = /apisix/dashboard {
-            content_by_lua_block {
-                ngx.exec("/apisix/dashboard/")
-            }
-        }
-
-        location /apisix/dashboard/ {
-            index index.html;
+        location /apisix/dashboard {
             {%if allow_admin then%}
                 {% for _, allow_ip in ipairs(allow_admin) do %}
                 allow {*allow_ip*};
@@ -251,11 +244,7 @@ http {
 
             alias dashboard/;
 
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Real-PORT $remote_port;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
-            try_files $uri $uri/ /index.html;
+            try_files $uri $uri/index.html /index.html;
         }
     }
     {% end %}
@@ -304,14 +293,7 @@ http {
             }
         }
 
-        location = /apisix/dashboard {
-            content_by_lua_block {
-                ngx.exec("/apisix/dashboard/")
-            }
-        }
-
         location /apisix/dashboard {
-            index index.html;
             {%if allow_admin then%}
                 {% for _, allow_ip in ipairs(allow_admin) do %}
                 allow {*allow_ip*};
@@ -321,11 +303,7 @@ http {
 
             alias dashboard/;
 
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Real-PORT $remote_port;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
-            try_files $uri $uri/ /index.html;
+            try_files $uri $uri/index.html /index.html;
         }
         {% end %}
 

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -124,22 +124,11 @@ http {
             }
         }
 
-        location = /apisix/dashboard {
-            content_by_lua_block {
-                ngx.exec("/apisix/dashboard/")
-            }
-        }
-
         location /apisix/dashboard {
-            index index.html;
 
             alias dashboard/;
 
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Real-PORT $remote_port;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
-            try_files $uri $uri/ /index.html;
+            try_files $uri $uri/index.html /index.html;
         }
 
         ssl_certificate_by_lua_block {

--- a/utils/install-apisix.sh
+++ b/utils/install-apisix.sh
@@ -42,10 +42,10 @@ echo $UNAME
 
 
 do_install() {
-    if [ "$UNAME" == "Darwin" ]; then
+    if [ "$UNAME" = "Darwin" ]; then
         luarocks install --lua-dir=$LUA_JIT_DIR $APISIX_VER --tree=/usr/local/apisix/deps --local
 
-    elif [ "$LUAROCKS_VER" == 'luarocks 3.' ]; then
+    elif [ "$LUAROCKS_VER" = 'luarocks 3.' ]; then
         luarocks install --lua-dir=$LUA_JIT_DIR $APISIX_VER --tree=/usr/local/apisix/deps --local
 
     else


### PR DESCRIPTION
NOTE: Please read the Contributing.md guidelines before submitting your patch:

https://github.com/apache/incubator-apisix/blob/master/Contributing.md#how-to-add-a-new-feature-or-change-an-existing-one

### Summary

Resolve issue #882 and simplify the nginx.conf
Also fix `utils/install-apisix.sh` as on `Debian/Ubuntu` the /bin/sh is a symbolic refer `/bin/dash` rather than `/bin/bash`, which not support `==` equal comparation.
```shell
$ ls -l /bin/sh
lrwxrwxrwx 1 root root 4 Oct  8 23:49 /bin/sh -> dash
```

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issues resolved

Fix #882 

1. The dashboard resources doesn't need proxy pass to upstream, remove the redundant `proxy_set_header`.
2. The direcctive `index index.html` is [the default setting by nginx](https://nginx.org/en/docs/http/ngx_http_index_module.html#index), remove it.
3. The internal redirect by `ngx.exec` is used to handle uri `/apisix/dashboard`, with can be solved by using `$uri/index.html` in `try_files`.
