### PR TITLE
Adding dev mode flag in config yaml to set the nginx worker_process

### DIFF
--- a/bin/apisix
+++ b/bin/apisix
@@ -80,7 +80,7 @@ local template = require("resty.template")
 local ngx_tpl = [=[
 master_process on;
 
-worker_processes auto;
+worker_processes {* worker_processes *};
 {% if os_name == "Linux" then %}
 worker_cpu_affinity auto;
 {% end %}
@@ -511,6 +511,12 @@ local function init()
     end
     for k,v in pairs(yaml_conf.nginx_config) do
         sys_conf[k] = v
+    end
+
+    if(sys_conf["enable_dev_mode"] == true) then
+        sys_conf["worker_processes"] = 1
+    else
+        sys_conf["worker_processes"] = "auto"
     end
 
     local conf_render = template.compile(ngx_tpl)

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -19,6 +19,7 @@ apisix:
   enable_heartbeat: true
   enable_admin: true
   enable_debug: false
+  enable_dev_mode: false          # Sets nginx worker_processes to 1 if set to true
   enable_ipv6: true
   config_center: etcd             # etcd: use etcd to store the config value
                                   # yaml: fetch the config value from local yaml file `/your_path/conf/apisix.yaml`


### PR DESCRIPTION
### Summary
Currently, there is no way to specify the number of worker_process for the dev mode. The PR sets the value of `1` for dev mode and `auto` for prod mode configs.

### Issues resolved

Fix #918
