### PR TITLE
feature: support showing apisix cluster node information

### DIFF
--- a/bin/apisix
+++ b/bin/apisix
@@ -568,7 +568,7 @@ local function init_etcd(show_output)
     for _, dir_name in ipairs({"/routes", "/upstreams", "/services",
                                "/plugins", "/consumers", "/node_status",
                                "/ssl", "/global_rules", "/stream_routes",
-                               "/proto"}) do
+                               "/proto", "/cluster"}) do
         local cmd = "curl " .. uri .. dir_name
                     .. "?prev_exist=false -X PUT -d dir=true "
                     .. "--connect-timeout " .. timeout

--- a/lua/apisix/admin/cluster.lua
+++ b/lua/apisix/admin/cluster.lua
@@ -1,0 +1,40 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+local core      = require("apisix.core")
+local pairs     = pairs
+
+local _M = {
+    version = 0.1,
+}
+
+function _M.get()
+    local key = "/cluster/"
+    local res, err = core.etcd.get(key, {recursive=true})
+    if not res then
+        core.log.error("failed to get node[", key, "]: ", err)
+        return 500, {error_msg = err}
+    end
+
+    local resp = {}
+    for _, node in pairs(res.body.node.nodes) do
+        resp[core.utils.split_uri(node.key)[4]] = node.value
+    end
+
+    return res.status, resp
+end
+
+return _M

--- a/lua/apisix/admin/init.lua
+++ b/lua/apisix/admin/init.lua
@@ -37,6 +37,7 @@ local resources = {
     proto           = require("apisix.admin.proto"),
     global_rules    = require("apisix.admin.global_rules"),
     stream_routes   = require("apisix.admin.stream_routes"),
+    cluster         = require("apisix.admin.cluster"),
 }
 
 

--- a/lua/apisix/plugins/node-status.lua
+++ b/lua/apisix/plugins/node-status.lua
@@ -86,23 +86,22 @@ local function collect_node_info()
 end
 
 local function report()
-    core.log.info("report...........")
     local data, err = collect_node_info()
     if not data then
-        core.log.error("failed to report node status:", err)
+        core.log.error("failed to report node information:", err)
     end
 
     local key = "/cluster/" .. apisix_id
     local res, err = core.etcd.set(key, data, 10)
     if not res then
-        core.log.error("failed to report node status[", key, "]: ", err)
+        core.log.error("failed to report node information[", key, "]: ", err)
     end
 end
 
 local function collect()
     local data, err = collect_node_info()
     if not data then
-        core.log.error("failed to report node status:", err)
+        core.log.error("failed to report node information:", err)
         return 500, err
     end
 

--- a/lua/apisix/plugins/node-status.lua
+++ b/lua/apisix/plugins/node-status.lua
@@ -101,7 +101,7 @@ end
 local function collect()
     local data, err = collect_node_info()
     if not data then
-        core.log.error("failed to report node information:", err)
+        core.log.error("failed to collect node information:", err)
         return 500, err
     end
 

--- a/t/admin/cluster.t
+++ b/t/admin/cluster.t
@@ -1,0 +1,54 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+master_on();
+repeat_each(1);
+no_long_string();
+no_root_location();
+no_shuffle();
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: sanity check
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local code, body, body_org = t('/apisix/admin/cluster', ngx.HTTP_GET)
+
+        if code >= 300 then
+            ngx.status = code
+        end
+        ngx.say(body_org)
+    }
+}
+--- request
+GET /t
+--- response_body eval
+qr/apisix_version/
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: test for unsupported method
+--- request
+PATCH /apisix/admin/cluster
+--- error_code: 404


### PR DESCRIPTION
**Summary**
1. Enhanced the /apisix/status api
2. Added the /apisix/admin/cluster/ api to show the cluster node information


**Full changelog**

Added the /apisix/cluster path in etcd and a timer in node-status plugin. The timer is triggered to update the node information every 5 seconds. The information of all apisix nodes will be recored in the /apisix/cluster path, which can be showed via /apisix/admin/cluster api.


Related to #459  