### PR TITLE
Jwt authentication plugin compatible with Bearer prefix

### DIFF
--- a/lua/apisix/plugins/jwt-auth.lua
+++ b/lua/apisix/plugins/jwt-auth.lua
@@ -21,6 +21,7 @@ local consumer = require("apisix.consumer")
 local ipairs   = ipairs
 local ngx      = ngx
 local ngx_time = ngx.time
+local sub_str  = string.sub
 local plugin_name = "jwt-auth"
 
 
@@ -90,14 +91,17 @@ end
 
 
 local function fetch_jwt_token()
+    local headers = ngx.req.get_headers()
+    if headers.Authorization then
+        if sub_str(headers.Authorization,1,7) == 'Bearer ' then
+            return sub_str(headers.Authorization,8)
+        end
+        return headers.Authorization
+    end
+
     local args = ngx.req.get_uri_args()
     if args and args.jwt then
         return args.jwt
-    end
-
-    local headers = ngx.req.get_headers()
-    if headers.Authorization then
-        return headers.Authorization
     end
 
     local cookie, err = ck:new()

--- a/lua/apisix/plugins/jwt-auth.lua
+++ b/lua/apisix/plugins/jwt-auth.lua
@@ -100,7 +100,7 @@ local function fetch_jwt_token(ctx)
         return token
     end
 
-    token = ngx.ctx.api_ctx.var.arg_jwt
+    token = ctx.var.arg_jwt
     if token then
         return token
     end

--- a/t/plugin/jwt-auth.t
+++ b/t/plugin/jwt-auth.t
@@ -237,6 +237,7 @@ hello world
 [error]
 
 
+
 === TEST 13: verify (in header without Bearer)
 --- request
 GET /hello
@@ -244,5 +245,30 @@ GET /hello
 Authorization: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTg3OTMxODU0MX0.fNtFJnNmJgzbiYmGB0Yjvm-l6A6M4jRV1l4mnVFSYjs
 --- response_body
 hello world
+--- no_error_log
+[error]
+
+
+
+=== TEST 14: verify (header with bearer)
+--- request
+GET /hello
+--- more_headers
+Authorization: bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTg3OTMxODU0MX0.fNtFJnNmJgzbiYmGB0Yjvm-l6A6M4jRV1l4mnVFSYjs
+--- response_body
+hello world
+--- no_error_log
+[error]
+
+
+
+=== TEST 15: verify (invalid bearer token)
+--- request
+GET /hello
+--- more_headers
+Authorization: bearer invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTg3OTMxODU0MX0.fNtFJnNmJgzbiYmGB0Yjvm-l6A6M4jRV1l4mnVFSYjs
+--- error_code: 401
+--- response_body
+{"message":"invalid header: invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"}
 --- no_error_log
 [error]

--- a/t/plugin/jwt-auth.t
+++ b/t/plugin/jwt-auth.t
@@ -235,3 +235,14 @@ Cookie: jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI
 hello world
 --- no_error_log
 [error]
+
+
+=== TEST 13: verify (in header without Bearer)
+--- request
+GET /hello
+--- more_headers
+Authorization: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTg3OTMxODU0MX0.fNtFJnNmJgzbiYmGB0Yjvm-l6A6M4jRV1l4mnVFSYjs
+--- response_body
+hello world
+--- no_error_log
+[error]

--- a/t/plugin/jwt-auth.t
+++ b/t/plugin/jwt-auth.t
@@ -218,7 +218,7 @@ hello world
 --- request
 GET /hello
 --- more_headers
-Authorization: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTg3OTMxODU0MX0.fNtFJnNmJgzbiYmGB0Yjvm-l6A6M4jRV1l4mnVFSYjs
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTg3OTMxODU0MX0.fNtFJnNmJgzbiYmGB0Yjvm-l6A6M4jRV1l4mnVFSYjs
 --- response_body
 hello world
 --- no_error_log


### PR DESCRIPTION
### Summary
   Jwt authentication plugin compatible with Bearer prefix

### Full changelog
 
1.  t/plugin/jwt-auth.t
2.  plugins/jwt-auth.lua 

### Issues resolved

Fix https://github.com/apache/incubator-apisix/issues/1026
