### PR TITLE
Comment: add tips in the generated nginx.conf (#1003)

### DIFF
--- a/bin/apisix
+++ b/bin/apisix
@@ -75,6 +75,9 @@ local yaml = require("tinyyaml")
 local template = require("resty.template")
 
 local ngx_tpl = [=[
+# Configuration File - Nginx Server Configs
+# This is a read-only file, do not try to modify it.
+
 master_process on;
 
 worker_processes {* worker_processes *};


### PR DESCRIPTION
### Summary

add tips in the generated nginx.conf

### Full changelog

* Edit file : bin/apisix  to declare that the nginx.conf  is a read-only file and do not try to modify it.

