### PR TITLE
doc: fix typo in 'The advantages of Apache APISIX'

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,9 +178,9 @@ Using AWS's 8 core server, APISIX's QPS reach to 140,000 with a latency of only 
 #### The advantages of Apache APISIX
 | **Features**   | **Apache APISIX**   | **Kong**   |
 |:----|:----|:----|
-| belongs to   | Apache Foundation   | Kong Inc.   |
+| belongs to   | Apache Software Foundation   | Kong Inc.   |
 | Tech Architecture | Nginx + etcd   | Nginx + postgres   |
-| Communication channels  | Mail list, Wechat qroup, QQ group, Github, meetup   | Github,freenode, forum   |
+| Communication channels  | Mail list, Wechat group, QQ group, Github, meetup   | Github,freenode, forum   |
 | Single-core CPU, QPS(enable limit-count and prometheus plugins)   | 18000   | 1700   |
 |  latency | 0.2 ms   | 2 ms   |
 | IPv6    | Yes   | No   |

--- a/README_CN.md
+++ b/README_CN.md
@@ -180,7 +180,7 @@ Dashboard 默认允许任何 IP 访问。你可以自行修改 `conf/config.yaml
 
 | **功能**   | **Apache APISIX**   | **KONG**   |
 |:----|:----|:----|
-| 项目归属   | Apache 基金会   | Kong Inc.   |
+| 项目归属   | Apache 软件基金会   | Kong Inc.   |
 | 技术架构   | Nginx + etcd   | Nginx + postgres   |
 | 交流渠道  | 微信群、QQ群、邮件列表、Github、meetup   | Github、论坛、freenode   |
 | 单核 QPS(开启限流和prometheus插件)   | 18000   | 1700   |


### PR DESCRIPTION
### Summary

fix typo inf Readme.md
change  `Apache Foundation` into `Apache Software Foundation`
I think the `Apache Software Foundation` is the offical name
### Full changelog

* README.md
