### PR TITLE
chore: improve the core.log module

### DIFF
--- a/lua/apisix/core/log.lua
+++ b/lua/apisix/core/log.lua
@@ -32,37 +32,22 @@ local log_levels = {
     error  = ngx.ERR,
     warn   = ngx.WARN,
     notice = ngx.NOTICE,
-    info   = ngx.INFO
+    info   = ngx.INFO,
+    debug  = ngx.DEBUG,
 }
 
 
-do
-    local cur_level
-
-function _M.debug(...)
-    if not cur_level then
-        cur_level = ngx.config.subsystem == "http" and
-                        require "ngx.errlog" .get_sys_filter_level()
-    end
-
-    if not DEBUG and cur_level and ngx_DEBUG > cur_level then
-        return
-    end
-
-    return ngx_log(ngx_DEBUG, ...)
-end
-
-end -- do
-
-
+local cur_level = ngx.config.subsystem == "http" and
+                  require "ngx.errlog" .get_sys_filter_level()
+local do_nothing = function() end
 setmetatable(_M, {__index = function(self, cmd)
-    local cur_level = ngx.config.subsystem == "http" and
-                        require "ngx.errlog" .get_sys_filter_level()
     local log_level = log_levels[cmd]
 
     local method
-    if cur_level and log_levels[cmd] > cur_level then
-        method = function() end
+    if cur_level and (log_level > cur_level or
+        (log_level == ngx_DEBUG and not DEBUG))
+    then
+        method = do_nothing
     else
         method = function(...)
             return ngx_log(log_level, ...)


### PR DESCRIPTION
1. implement the debug method with the generic logic, so you don't need
to go into the method if you don't need it.
2. avoid computing the same result among different log levels