### PR TITLE
Batch processor util to process the logs in batches

### DIFF
--- a/lua/apisix/plugins/batch-processor.lua
+++ b/lua/apisix/plugins/batch-processor.lua
@@ -1,0 +1,235 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+local setmetatable = setmetatable
+local timer_at = ngx.timer.at
+local remove = table.remove
+local type = type
+local huge = math.huge
+local fmt = string.format
+local now = ngx.now
+local ngx_log = ngx.log
+local DEBUG = ngx.DEBUG
+local core = require("apisix.core")
+local assert = assert
+local Batch_Processor = {}
+local Batch_Processor_mt = {
+    __index = Batch_Processor
+}
+-- Forward function declarations
+local flush
+local process
+
+
+-------------------------------------------------------------------------------
+-- Create a timer for the `flush` operation.
+-- @param self Queue
+local function schedule_flush(self)
+    local ok, err = timer_at(self.flush_timeout/1000, flush, self)
+    if not ok then
+        core.log.error("failed to create delayed flush timer: ", err)
+        return
+    end
+    self.flush_scheduled = true
+end
+
+
+-------------------------------------------------------------------------------
+-- Create a timer for the `process` operation.
+-- @param self Batch_Processor
+-- @param batch: table with `entries` and `retry_count` counter
+-- @param delay number: timer delay in seconds
+local function schedule_process(self, batch, delay)
+    local ok, err = timer_at(delay, process, self, batch)
+    if not ok then
+        core.log.error("failed to create process timer: ", err)
+        return
+    end
+end
+
+-----------------
+-- Timer handlers
+-----------------
+
+
+-------------------------------------------------------------------------------
+-- Get the current time.
+-- @return current time in seconds
+local function get_now()
+    return now()*1000
+end
+
+
+-------------------------------------------------------------------------------
+-- Timer callback for triggering flush the current batch.
+-- @param premature boolean: ngx.timer premature indicator
+-- @param self Batch_Processor
+-- @return nothing
+flush = function(premature, self)
+    if premature then
+        return
+    end
+
+    if get_now() - self.last_activity < self.flush_timeout then
+        ngx_log(DEBUG, fmt("BatchProcessor[%s] had activitity delayin the flush", self.name))
+        schedule_flush(self)
+        return
+    end
+
+    -- no activity and timeout reached
+    ngx_log(DEBUG, fmt("BatchProcessor[%s] activating flush due to no activity, flushing triggered by flush_timeout", self.name))
+    self:flush()
+    self.flush_scheduled = false
+end
+
+
+-------------------------------------------------------------------------------
+-- Timer callback for issuing the `self.process` operation
+-- @param premature boolean: ngx.timer premature indicator
+-- @param self Queue
+-- @param batch: table with `entries` and `retry_count` counter
+-- @return nothing
+process = function(premature, self, batch)
+    if premature then
+        return
+    end
+
+    local ok, err = self.process(batch.entries)
+    if ok then -- success, reset retry delays
+        ngx_log(DEBUG, fmt("Batch Processor[%s] successfully processed the entries", self.name))
+
+    else
+        batch.retry_count = batch.retry_count + 1
+        if batch.retry_count < self.max_retry_count then
+            core.log.warn(fmt("Batch Processor[%s] failed to process entries: ", self.name), err)
+            schedule_process(self, batch, self.retry_delay)
+        else
+            core.log.error(fmt("Batch Processor[%s] exceeded the max_retry_count[%d], dropping the entries", self.name, batch.retry_count))
+        end
+    end
+end
+
+
+---------
+-- Batch Processor
+---------
+
+
+-------------------------------------------------------------------------------
+-- Initialize a batch processor with background retryable processing
+-- @param process function, invoked to process every payload generated
+-- @param opts table, optionally including
+-- `max_retry_count`, `flush_timeout`, `batch_max_size` and `process_delay`
+-- @return table: a Queue object.
+function Batch_Processor:new(process, opts)
+    opts = opts or {}
+
+    assert(type(process) == "function",
+        "arg #1 (process) must be a function")
+    assert(type(opts) == "table",
+        "arg #2 (opts) must be a table")
+    assert(opts.max_retry_count == nil or type(opts.max_retry_count) == "number",
+        "max_retry_count must be a number")
+    assert(opts.flush_timeout == nil or type(opts.flush_timeout) == "number",
+        "flush_timeout must be a number")
+    assert(opts.batch_max_size == nil or type(opts.batch_max_size) == "number",
+        "batch_max_size must be a number")
+    assert(opts.process_delay == nil or type(opts.process_delay) == "number",
+        "process_delay must be a number")
+    assert(opts.retry_delay == nil or type(opts.retry_delay) == "number",
+        "retry_delay must be a number")
+
+    local self = {
+        process = process,
+
+        -- flush timeout in milliseconds
+        flush_timeout = opts.flush_timeout and opts.flush_timeout * 1000 or 5000,
+        max_retry_count = opts.max_retry_count or 0,
+        batch_max_size = opts.batch_max_size or 1000, -- maximum number of entries in a batch before the batch must be transmitted
+        process_delay = opts.process_delay or 1,
+        retry_delay = opts.retry_delay or 1,
+        name = opts.name or "log buffer",
+
+        batch_to_process = {},
+        current_batch = { entries = {}, count = 0, retry_count = 0 },
+        flush_scheduled = false,
+        last_activity = huge,
+    }
+
+    return setmetatable(self, Batch_Processor_mt)
+end
+
+
+-------------------------------------------------------------------------------
+-- Add data to the current batch
+-- @param entry the value included in the current batch. It can be any Lua value besides nil.
+-- @return true, or nil and an error message.
+function Batch_Processor:add(entry)
+    if entry == nil then
+        return nil, "entry must be a non-nil Lua value"
+    end
+
+    if self.batch_max_size == 1 then
+        -- no batching
+        local batch = { entries = { entry }, retry_count = 0 }
+        schedule_process(self, batch, 0)
+        return true
+    end
+
+    local cb = self.current_batch
+    local new_size = #cb.entries + 1
+    cb.entries[new_size] = entry
+
+    if new_size >= self.batch_max_size then
+        local ok, err = self:flush()
+        if not ok then
+            return nil, err
+        end
+
+    elseif not self.flush_scheduled then
+        schedule_flush(self)
+    end
+
+    self.last_activity = get_now()
+    return true
+end
+
+
+-------------------------------------------------------------------------------
+-- * Close the current batch and place it the processing
+-- * Start a new empty batch
+-- * Schedule processing if needed.
+-- @return true, or nil and an error message.
+function Batch_Processor:flush()
+    local current_batch_size = #self.current_batch.entries
+
+    -- Move the current batch to processing if its not empty
+    if current_batch_size > 0 then
+        ngx_log(DEBUG, "Moving current batch to processing, current batch size[", current_batch_size, "]")
+        self.batch_to_process[#self.batch_to_process + 1] = self.current_batch
+        self.current_batch = { entries = {}, retry_count = 0 }
+    end
+
+    repeat
+        local oldest_batch = remove(self.batch_to_process, 1)
+        schedule_process(self, oldest_batch, self.process_delay)
+    until(#self.batch_to_process == 0)
+
+    return true
+end
+
+
+return Batch_Processor

--- a/lua/apisix/plugins/batch-processor.lua
+++ b/lua/apisix/plugins/batch-processor.lua
@@ -63,8 +63,6 @@ end
 -----------------
 -- Timer handlers
 -----------------
-
-
 -------------------------------------------------------------------------------
 -- Get the current time.
 -- @return current time in seconds
@@ -126,8 +124,6 @@ end
 ---------
 -- Batch Processor
 ---------
-
-
 -------------------------------------------------------------------------------
 -- Initialize a batch processor with background retryable processing
 -- @param process function, invoked to process every payload generated
@@ -154,15 +150,12 @@ function Batch_Processor:new(process, opts)
 
     local self = {
         process = process,
-
-        -- flush timeout in milliseconds
-        flush_timeout = opts.flush_timeout and opts.flush_timeout * 1000 or 5000,
+        flush_timeout = opts.flush_timeout and opts.flush_timeout * 1000 or 5000, -- flush timeout in milliseconds
         max_retry_count = opts.max_retry_count or 0,
         batch_max_size = opts.batch_max_size or 1000, -- maximum number of entries in a batch before the batch must be transmitted
         process_delay = opts.process_delay or 1,
         retry_delay = opts.retry_delay or 1,
         name = opts.name or "log buffer",
-
         batch_to_process = {},
         current_batch = { entries = {}, count = 0, retry_count = 0 },
         flush_scheduled = false,

--- a/t/plugin/batch-processor.t
+++ b/t/plugin/batch-processor.t
@@ -1,0 +1,305 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+log_level('debug');
+repeat_each(1);
+no_long_string();
+no_root_location();
+run_tests;
+
+__DATA__
+
+=== TEST 1: sanity
+--- config
+    location /t {
+        content_by_lua_block {
+            local Batch = require("apisix.plugins.batch-processor")
+            local opts = {
+                max_retry_count  = 2,
+                flush_timeout  = 5,
+                batch_max_size = 1,
+                process_delay  = 0,
+                retry_delay  = 0,
+            }
+
+            local func_to_send = function(elements)
+                return true
+            end
+
+            local log_buffer, err = Batch:new(func_to_send, opts)
+
+            if not log_buffer then
+                ngx.say(err)
+            end
+
+            log_buffer:add({hello='world'})
+            ngx.say("done")
+        }
+    }
+--- request
+GET /t
+--- response_body
+done
+--- error_log
+Batch Processor[log buffer] successfully processed the entries
+--- wait: 0.5
+
+=== TEST 2: batch processor timeout exceeded
+--- config
+    location /t {
+        content_by_lua_block {
+            local Batch = require("apisix.plugins.batch-processor")
+            local opts = {
+                max_retry_count  = 2,
+                flush_timeout  = 0,
+                batch_max_size = 2,
+                process_delay  = 0,
+                retry_delay  = 0,
+            }
+
+            local func_to_send = function(elements)
+                return true
+            end
+
+            local log_buffer, err = Batch:new(func_to_send, opts)
+
+            if not log_buffer then
+                ngx.say(err)
+            end
+
+            log_buffer:add({hello='world'})
+            ngx.say("done")
+        }
+    }
+--- request
+GET /t
+--- response_body
+done
+--- error_log
+BatchProcessor[log buffer] activating flush due to no activity
+Batch Processor[log buffer] successfully processed the entries
+--- wait: 0.10
+
+
+=== TEST 3: batch processor batch max size exceeded
+--- config
+    location /t {
+        content_by_lua_block {
+            local Batch = require("apisix.plugins.batch-processor")
+
+            local opts = {
+                max_retry_count  = 2,
+                flush_timeout  = 5,
+                batch_max_size = 2,
+                process_delay  = 0,
+                retry_delay  = 0,
+            }
+
+            local func_to_send = function(elements)
+                return true
+            end
+
+            local log_buffer, err = Batch:new(func_to_send, opts)
+
+            if not log_buffer then
+                ngx.say(err)
+            end
+
+            log_buffer:add({hello='world'})
+            log_buffer:add({hello='world'})
+            ngx.say("done")
+        }
+    }
+--- request
+GET /t
+--- response_body
+done
+--- no_error_log
+BatchProcessor[log buffer] activating flush due to no activity
+--- error_log
+Batch Processor[log buffer] successfully processed the entries
+--- wait: 0.5
+
+=== TEST 4: first failed to process and second try success
+--- config
+    location /t {
+        content_by_lua_block {
+            local Batch = require("apisix.plugins.batch-processor")
+            local core = require("apisix.core")
+            local retry = false
+            local opts = {
+                max_retry_count  = 2,
+                flush_timeout  = 5,
+                batch_max_size = 2,
+                process_delay  = 0,
+                retry_delay  = 0,
+            }
+
+            local func_to_send = function(elements)
+                if not retry then
+                    retry = true
+                    return false
+                end
+                return true
+            end
+
+            local log_buffer, err = Batch:new(func_to_send, opts)
+
+            if not log_buffer then
+                ngx.say(err)
+            end
+
+            log_buffer:add({hello='world'})
+            log_buffer:add({hello='world'})
+            ngx.say("done")
+        }
+    }
+--- request
+GET /t
+--- response_body
+done
+--- error_log
+Batch Processor[log buffer] failed to process entries
+Batch Processor[log buffer] successfully processed the entries
+--- wait: 0.5
+
+=== TEST 5: batch processor batch max size exceeded
+--- config
+    location /t {
+        content_by_lua_block {
+            local Batch = require("apisix.plugins.batch-processor")
+
+            local opts = {
+                max_retry_count  = 2,
+                flush_timeout  = 5,
+                batch_max_size = 2,
+                process_delay  = 0,
+                retry_delay  = 0,
+            }
+
+            local func_to_send = function(elements)
+                return false
+            end
+
+            local log_buffer, err = Batch:new(func_to_send, opts)
+
+            if not log_buffer then
+                ngx.say(err)
+            end
+
+            log_buffer:add({hello='world'})
+            log_buffer:add({hello='world'})
+            ngx.say("done")
+        }
+    }
+--- request
+GET /t
+--- response_body
+done
+--- no_error_log
+BatchProcessor[log buffer] activating flush due to no activity
+--- error_log
+Batch Processor[log buffer] failed to process entries
+Batch Processor[log buffer] exceeded the max_retry_count
+--- wait: 0.5
+
+
+=== TEST 6: two batches
+--- config
+    location /t {
+        content_by_lua_block {
+            local Batch = require("apisix.plugins.batch-processor")
+            local core = require("apisix.core")
+            local count = 0
+            local opts = {
+                max_retry_count  = 2,
+                flush_timeout  = 5,
+                batch_max_size = 2,
+                process_delay  = 0,
+                retry_delay  = 0,
+            }
+
+            local func_to_send = function(elements)
+                count = count + 1
+                core.log.info("batch[", count , "] sent")
+                return true
+            end
+
+            local log_buffer, err = Batch:new(func_to_send, opts)
+
+            if not log_buffer then
+                ngx.say(err)
+            end
+
+            log_buffer:add({hello='world'})
+            log_buffer:add({hello='world'})
+            log_buffer:add({hello='world'})
+            log_buffer:add({hello='world'})
+            ngx.say("done")
+        }
+    }
+--- request
+GET /t
+--- response_body
+done
+--- no_error_log
+BatchProcessor[log buffer] activating flush due to no activity
+--- error_log
+batch[1] sent
+batch[2] sent
+--- wait: 0.5
+
+=== TEST 7: batch processor retry count 0 and fail processing
+--- config
+    location /t {
+        content_by_lua_block {
+            local Batch = require("apisix.plugins.batch-processor")
+
+            local opts = {
+                max_retry_count  = 0,
+                flush_timeout  = 5,
+                batch_max_size = 2,
+                process_delay  = 0,
+                retry_delay  = 0,
+            }
+
+            local func_to_send = function(elements)
+                return false
+            end
+
+            local log_buffer, err = Batch:new(func_to_send, opts)
+
+            if not log_buffer then
+                ngx.say(err)
+            end
+
+            log_buffer:add({hello='world'})
+            log_buffer:add({hello='world'})
+            ngx.say("done")
+        }
+    }
+--- request
+GET /t
+--- response_body
+done
+--- no_error_log
+BatchProcessor[log buffer] activating flush due to no activity
+Batch Processor[log buffer] failed to process entries
+--- error_log
+Batch Processor[log buffer] exceeded the max_retry_count
+--- wait: 0.5

--- a/t/plugin/batch-processor.t
+++ b/t/plugin/batch-processor.t
@@ -57,7 +57,7 @@ GET /t
 done
 --- error_log
 Batch Processor[log buffer] successfully processed the entries
---- wait: 0.5
+--- wait: 1
 
 === TEST 2: batch processor timeout exceeded
 --- config
@@ -93,7 +93,7 @@ done
 --- error_log
 BatchProcessor[log buffer] activating flush due to no activity
 Batch Processor[log buffer] successfully processed the entries
---- wait: 0.10
+--- wait: 1
 
 
 === TEST 3: batch processor batch max size exceeded
@@ -133,7 +133,7 @@ done
 BatchProcessor[log buffer] activating flush due to no activity
 --- error_log
 Batch Processor[log buffer] successfully processed the entries
---- wait: 0.5
+--- wait: 1
 
 === TEST 4: first failed to process and second try success
 --- config
@@ -176,7 +176,7 @@ done
 --- error_log
 Batch Processor[log buffer] failed to process entries
 Batch Processor[log buffer] successfully processed the entries
---- wait: 0.5
+--- wait: 1
 
 === TEST 5: batch processor batch max size exceeded
 --- config
@@ -216,7 +216,7 @@ BatchProcessor[log buffer] activating flush due to no activity
 --- error_log
 Batch Processor[log buffer] failed to process entries
 Batch Processor[log buffer] exceeded the max_retry_count
---- wait: 0.5
+--- wait: 1
 
 
 === TEST 6: two batches
@@ -262,7 +262,7 @@ BatchProcessor[log buffer] activating flush due to no activity
 --- error_log
 batch[1] sent
 batch[2] sent
---- wait: 0.5
+--- wait: 1
 
 === TEST 7: batch processor retry count 0 and fail processing
 --- config
@@ -302,4 +302,4 @@ BatchProcessor[log buffer] activating flush due to no activity
 Batch Processor[log buffer] failed to process entries
 --- error_log
 Batch Processor[log buffer] exceeded the max_retry_count
---- wait: 0.5
+--- wait: 1


### PR DESCRIPTION
The following is inspired by the following [batch processor util](https://github.com/Kong/kong/blob/master/kong/tools/batch_queue.lua) implementation (Apache 2) and includes the following modifications to the source file.

- Renamed Queue to Batch_Processor
- Added comprehensive test cases covering the edge case scenarios
- Refactored to parallel process the batch instead of appending the failed items as the last element of the array
- Converted the logs to use the core logging module
- Introduced an additional attribute(name) to the batch processor and enhanced the logging by appending the processor name to the logs to exactly identify the failed processes.
- Fixed the wrong assertion for [process_delay](https://github.com/Kong/kong/blob/619de297b0a68769bd38cff49f7810030851b550/kong/tools/batch_queue.lua#L234) in the original source file
- Renamed the following variables(batch_size => batch_max_size, retries => retry_count, batch_queue => batch_to_process )

Questions:
The `core.log.debug` statement does not create the debug logs during the unit test. Only the `ngx_log(DEBUG, "msg")` method prints the debug logs in the unit test. Is there any additional variable needed to be set?