### PR TITLE
doc: add description of redis_password in limit-count doc

### DIFF
--- a/doc/plugins/limit-count-cn.md
+++ b/doc/plugins/limit-count-cn.md
@@ -34,6 +34,7 @@
 |policy        |可选     |用于检索和增加限制的速率限制策略。可选的值有：`local`(计数器被以内存方式保存在节点本地，默认选项) 和 `redis`(计数器保存在 Redis 服务节点上，从而可以跨节点共享结果，通常用它来完成全局限速).|
 |redis_host    |可选     |当使用 `redis` 限速策略时，该属性是 Redis 服务节点的地址。|
 |redis_port    |可选     |当使用 `redis` 限速策略时，该属性是 Redis 服务节点的端口，默认端口 6379。|
+|redis_password|可选     |当使用 `redis` 限速策略时，该属性是 Redis 服务节点的密码。|
 |redis_timeout |可选     |当使用 `redis` 限速策略时，该属性是 Redis 服务节点以毫秒为单位的超时时间，默认是 1000 ms（1 秒）。|
 
 ### 示例
@@ -85,6 +86,7 @@ curl -i http://127.0.0.1:9080/apisix/admin/routes/1 -X PUT -d '
             "policy": "redis",
             "redis_host": "127.0.0.1",
             "redis_port": 6379,
+            "redis_password": "password",
             "redis_timeout": 1001
         }
     },

--- a/doc/plugins/limit-count.md
+++ b/doc/plugins/limit-count.md
@@ -41,6 +41,7 @@ Limit request rate by a fixed number of requests in a given time window.
 |policy        |optional|The rate-limiting policies to use for retrieving and incrementing the limits. Available values are `local`(the counters will be stored locally in-memory on the node, default value) and `redis`(counters are stored on a Redis server and will be shared across the nodes, usually used it to do the global speed limit).|
 |redis_host    |optional|When using the `redis` policy, this property specifies the address of the Redis server.|
 |redis_port    |optional|When using the `redis` policy, this property specifies the port of the Redis server. The default port is 6379.|
+|redis_password|optional|When using the `redis` policy, this property specifies the password of the Redis server.|
 |redis_timeout |optional|When using the `redis` policy, this property specifies the timeout in milliseconds of any command submitted to the Redis server. The default timeout is 1000 ms(1 second).|
 
 ## How To Enable
@@ -91,6 +92,7 @@ curl -i http://127.0.0.1:9080/apisix/admin/routes/1 -X PUT -d '
             "policy": "redis",
             "redis_host": "127.0.0.1",
             "redis_port": 6379,
+            "redis_password": "password",
             "redis_timeout": 1001
         }
     },


### PR DESCRIPTION
### Summary

add description of redis_password in limit-count doc

### Issues resolved

Fix #1171
