### PR TITLE
fix: global ruls admin api should list resource without id

### DIFF
--- a/lua/apisix/admin/global_rules.lua
+++ b/lua/apisix/admin/global_rules.lua
@@ -77,7 +77,10 @@ end
 
 
 function _M.get(id)
-    local key = "/global_rules/" .. id
+    local key = "/global_rules"
+    if id then
+        key = key .. "/" .. id
+    end
     local res, err = core.etcd.get(key)
     if not res then
         core.log.error("failed to get global rule[", key, "]: ", err)

--- a/t/admin/global-rules.t
+++ b/t/admin/global-rules.t
@@ -111,9 +111,51 @@ passed
 --- no_error_log
 [error]
 
+=== TEST 3: list global rules
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/global_rules',
+                ngx.HTTP_GET,
+                nil,
+                [[{
+                    "node": {
+                        "dir": true,
+                        "nodes": [
+                        {
+                            "key": "/apisix/global_rules/1",
+                            "value": {
+                            "plugins": {
+                                "limit-count": {
+                                "time_window": 60,
+                                "policy": "local",
+                                "count": 2,
+                                "key": "remote_addr",
+                                "rejected_code": 503
+                                }
+                            }
+                            }
+                        }
+                        ],
+                        "key": "/apisix/global_rules",
+                    },
+                    "action": "get"
+                }]]
+                )
 
+            ngx.status = code
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
 
-=== TEST 3: PATCH global rules
+=== TEST 4: PATCH global rules
 --- config
     location /t {
         content_by_lua_block {
@@ -159,7 +201,7 @@ passed
 
 
 
-=== TEST 4: delete global rules
+=== TEST 5: delete global rules
 --- config
     location /t {
         content_by_lua_block {
@@ -183,7 +225,7 @@ GET /t
 
 
 
-=== TEST 5: delete global rules(not_found)
+=== TEST 6: delete global rules(not_found)
 --- config
     location /t {
         content_by_lua_block {
@@ -207,7 +249,7 @@ GET /t
 
 
 
-=== TEST 6: set global rules(invalid host option)
+=== TEST 7: set global rules(invalid host option)
 --- config
     location /t {
         content_by_lua_block {
@@ -241,7 +283,7 @@ GET /t
 
 
 
-=== TEST 7: set global rules(missing plugins)
+=== TEST 8: set global rules(missing plugins)
 --- config
     location /t {
         content_by_lua_block {

--- a/t/admin/global-rules.t
+++ b/t/admin/global-rules.t
@@ -138,7 +138,7 @@ passed
                             }
                         }
                         ],
-                        "key": "/apisix/global_rules",
+                        "key": "/apisix/global_rules"
                     },
                     "action": "get"
                 }]]


### PR DESCRIPTION
# Summary
apisix admin api will return error when access "/apisix/admin/global_rules",

### Issues resolved

Fix: return all resource when access root.

BTW: i dont see any test case about 'list' action of admin api except 'get', so i did't add external cases.
