### PR TITLE
CI: enabled all CI env.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: required
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - os: osx
-    - env: OSNAME=linux_apisix_luarocks
+  # allow_failures:
+    # - os: osx
+    # - env: OSNAME=linux_apisix_luarocks
 
   include:
     - os: linux

--- a/bin/apisix
+++ b/bin/apisix
@@ -37,6 +37,7 @@ local apisix_home = "/usr/local/apisix"
 local pkg_cpath = apisix_home .. "/deps/lib64/lua/5.1/?.so;"
                   .. apisix_home .. "/deps/lib/lua/5.1/?.so;;"
 local pkg_path  = apisix_home .. "/deps/share/lua/5.1/apisix/lua/?.lua;"
+                  .. "/usr/local/share/lua/5.1/apisix/lua/?.lua;"
                   .. apisix_home .. "/deps/share/lua/5.1/?.lua;;"
 
 -- only for developer, use current folder as working space


### PR DESCRIPTION
Previously, some tests were closed due to the long running time of Travis, but now they must be opened to avoid these CI becoming useless decorations