### PR TITLE
feature: add example .yaml resource files which support to run Apache APISIX on kubernetes

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -23,6 +23,18 @@
 
 ```
 $ kubectl apply -f apisix-gw-config-cm.yaml
+
+or
+
+$ kubectl create configmap apisix-gw-config.yaml --from-file=../conf/config.yaml
+```
+
+##### Note: you should modify etcd addr in config file `apisix-gw-config-cm.yaml` or `../conf/config.yaml` first
+
+```
+etcd:
+  host:                           # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
+    - "http://127.0.0.1:2379"     # multiple etcd address
 ```
 
 #### Create deployment for apache incubator-apisix

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,54 @@
+### Usage
+
+#### Create configmap for apache incubator-apisix
+
+```
+$ kubectl apply -f apisix-gw-config-cm.yaml
+```
+
+#### Create deployment for apache incubator-apisix
+
+```
+$ kubectl apply -f deployment.yaml
+```
+
+#### Create service for apache incubator-apisix
+
+```
+$ kubectl apply -f service.yaml
+```
+
+#### Create service for apache incubator-apisix (when using Aliyun SLB)
+
+```
+$ kubectl apply -f service-aliyun-slb.yaml
+```
+
+#### Scale apache incubator-apisix
+
+```
+$ kubectl scale deployment apisix-gw-deployment --replicas=4
+```
+
+#### Check running status
+
+```
+$ kubectl get cm | grep -i apisix
+apisix-gw-config.yaml                             1      1d
+
+$ kubectl get pod | grep -i apisix
+apisix-gw-deployment-68df7c7578-5pvxb   1/1     Running   0          1d
+apisix-gw-deployment-68df7c7578-kn89l   1/1     Running   0          1d
+apisix-gw-deployment-68df7c7578-i830r   1/1     Running   0          1d
+apisix-gw-deployment-68df7c7578-32ow1   1/1     Running   0          1d
+
+$ kubectl get svc | grep -i apisix
+apisix-gw-svc            LoadBalancer   172.19.33.28    10.253.0.11   80:31141/TCP,443:30931/TCP                  1d
+
+```
+
+#### Clean up
+
+```
+kubectl delete -f .
+```

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,4 +1,4 @@
-<!-- 
+<!--
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,3 +1,22 @@
+<!-- 
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
 ### Usage
 
 #### Create configmap for apache incubator-apisix
@@ -47,7 +66,7 @@ apisix-gw-svc            LoadBalancer   172.19.33.28    10.253.0.11   80:31141/T
 
 ```
 
-#### Clean up
+#### Clean up (dangerous)
 
 ```
 kubectl delete -f .

--- a/kubernetes/apisix-gw-config-cm.yaml
+++ b/kubernetes/apisix-gw-config-cm.yaml
@@ -1,0 +1,137 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    #
+    # Licensed to the Apache Software Foundation (ASF) under one or more
+    # contributor license agreements.  See the NOTICE file distributed with
+    # this work for additional information regarding copyright ownership.
+    # The ASF licenses this file to You under the Apache License, Version 2.0
+    # (the "License"); you may not use this file except in compliance with
+    # the License.  You may obtain a copy of the License at
+    #
+    #     http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+    #
+    apisix:
+      node_listen: 9080              # APISIX listening port
+      enable_heartbeat: true
+      enable_admin: true
+      enable_admin_cors: true         # Admin API support CORS response headers.
+      enable_debug: false
+      enable_dev_mode: false          # Sets nginx worker_processes to 1 if set to true
+      enable_reuseport: true          # Enable nginx SO_REUSEPORT switch if set to true.
+      enable_ipv6: true
+      config_center: etcd             # etcd: use etcd to store the config value
+                                      # yaml: fetch the config value from local yaml file `/your_path/conf/apisix.yaml`
+
+      #proxy_protocol:                 # Proxy Protocol configuration
+      #  listen_http_port: 9181        # The port with proxy protocol for http, it differs from node_listen and port_admin.
+                                      # This port can only receive http request with proxy protocol, but node_listen & port_admin
+                                      # can only receive http request. If you enable proxy protocol, you must use this port to
+                                      # receive http request with proxy protocol
+      #  listen_https_port: 9182       # The port with proxy protocol for https
+      #  enable_tcp_pp: true           # Enable the proxy protocol for tcp proxy, it works for stream_proxy.tcp option
+      #  enable_tcp_pp_to_upstream: true # Enables the proxy protocol to the upstream server
+
+      # allow_admin:                  # http://nginx.org/en/docs/http/ngx_http_access_module.html#allow
+      #   - 127.0.0.0/24              # If we don't set any IP list, then any IP access is allowed by default.
+      #   - "::/64"
+      # port_admin: 9180              # use a separate port
+
+      # Default token when use API to call for Admin API.
+      # *NOTE*: Highly recommended to modify this value to protect APISIX's Admin API.
+      # Disabling this configuration item means that the Admin API does not
+      # require any authentication.
+      admin_key:
+        -
+          name: "admin"
+          key: edd1c9f034335f136f87ad84b625c8f1
+          role: admin                 # admin: manage all configuration data
+                                      # viewer: only can view configuration data
+        -
+          name: "viewer"
+          key: 4054f7cf07e344346cd3f287985e76a2
+          role: viewer
+      router:
+        http: 'radixtree_uri'         # radixtree_uri: match route by uri(base on radixtree)
+                                      # radixtree_host_uri: match route by host + uri(base on radixtree)
+        ssl: 'radixtree_sni'          # radixtree_sni: match route by SNI(base on radixtree)
+      # stream_proxy:                 # TCP/UDP proxy
+      #   tcp:                        # TCP proxy port list
+      #     - 9100
+      #     - 9101
+      #   udp:                        # UDP proxy port list
+      #     - 9200
+      #     - 9211
+      dns_resolver:                   # default DNS resolver, with disable IPv6 and enable local DNS
+        - 114.114.114.114
+        - 223.5.5.5
+        - 1.1.1.1
+        - 8.8.8.8
+      dns_resolver_valid: 30          # valid time for dns result 30 seconds
+
+      ssl:
+        enable: true
+        enable_http2: true
+        listen_port: 9443
+        ssl_protocols: "TLSv1 TLSv1.1 TLSv1.2 TLSv1.3"
+        ssl_ciphers: "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA"
+
+    nginx_config:                     # config for render the template to genarate nginx.conf
+      error_log: "logs/error.log"
+      error_log_level: "warn"         # warn,error
+      worker_rlimit_nofile: 20480     # the number of files a worker process can open, should be larger than worker_connections
+      event:
+        worker_connections: 10620
+      http:
+        access_log: "logs/access.log"
+        keepalive_timeout: 60s         # timeout during which a keep-alive client connection will stay open on the server side.
+        client_header_timeout: 60s     # timeout for reading client request header, then 408 (Request Time-out) error is returned to the client
+        client_body_timeout: 60s       # timeout for reading client request body, then 408 (Request Time-out) error is returned to the client
+        send_timeout: 10s              # timeout for transmitting a response to the client.then the connection is closed
+        underscores_in_headers: "on"   # default enables the use of underscores in client request header fields
+        real_ip_header: "X-Real-IP"    # http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header
+        real_ip_from:                  # http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from
+          - 127.0.0.1
+          - 'unix:'
+
+    etcd:
+      host: "http://127.0.0.1:2379"   # etcd address
+      prefix: "/apisix"               # apisix configurations prefix
+      timeout: 3                      # 3 seconds
+
+    plugins:                          # plugin list
+      - example-plugin
+      - limit-req
+      - limit-count
+      - limit-conn
+      - key-auth
+      - basic-auth
+      - prometheus
+      - node-status
+      - jwt-auth
+      - zipkin
+      - ip-restriction
+      - grpc-transcode
+      - serverless-pre-function
+      - serverless-post-function
+      - openid-connect
+      - proxy-rewrite
+      - redirect
+      - response-rewrite
+      - fault-injection
+      - udp-logger
+      - wolf-rbac
+
+    stream_plugins:
+      - mqtt-proxy
+
+kind: ConfigMap
+metadata:
+  name: apisix-gw-config.yaml
+  # namespace: default

--- a/kubernetes/apisix-gw-config-cm.yaml
+++ b/kubernetes/apisix-gw-config-cm.yaml
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 apiVersion: v1
 data:
   config.yaml: |

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -126,8 +126,8 @@ spec:
               exec:
                 command:
                 - /bin/sh
-                - c
-                - sleep 30
+                - -c
+                - "sleep 30"
           # cpu core(s), 1 == 1000m
           resources:
             limits:

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -88,7 +88,6 @@ spec:
           image: 'YOUR_APISIX_IMAGE_URL:latest'
           imagePullPolicy: IfNotPresent
           name: apisix-gw-deployment
-          # 
           ports:
           - containerPort: 9080
             name: http

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 apiVersion: apps/v1beta2 # for versions before 1.8.0 use apps/v1beta1
 kind: Deployment
 metadata:

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -85,7 +85,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
-          image: 'YOUR_APISIX_IMAGE_URL:latest'
+          image: 'apache/apisix:latest'
           imagePullPolicy: IfNotPresent
           name: apisix-gw-deployment
           ports:

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -1,0 +1,149 @@
+apiVersion: apps/v1beta2 # for versions before 1.8.0 use apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: apisix-gw
+  name: apisix-gw-deployment
+  # namespace: default
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: apisix-gw
+  template:
+    metadata:
+      labels:
+        app: apisix-gw
+    spec:
+      # tolerations:
+      # - key: "group"
+      #   operator: "Equal"
+      #   value: "prod"
+      #   effect: "NoSchedule"
+      # nodeSelector:
+      #   env: prod
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - apisix-gw
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      initContainers:
+      - command:
+        - /bin/sh
+        - -c
+        - |
+          sysctl -w net.core.somaxconn=65535
+          sysctl -w net.ipv4.ip_local_port_range="1024 65535"
+          sysctl -w net.ipv4.tcp_max_syn_backlog=8192
+          sysctl -w fs.file-max=1048576
+          sysctl -w fs.inotify.max_user_instances=16384
+          sysctl -w fs.inotify.max_user_watches=524288
+          sysctl -w fs.inotify.max_queued_events=16384
+        image: busybox:latest
+        name: init-sysctl
+        resources: {}
+        securityContext:
+          privileged: true
+          procMount: Default
+      restartPolicy: Always
+
+      containers:
+        - env:
+            - name: TZ
+              value: "Asia/Shanghai"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+          image: 'YOUR_APISIX_IMAGE_URL:latest'
+          imagePullPolicy: IfNotPresent
+          name: apisix-gw-deployment
+          # 
+          ports:
+          - containerPort: 9080
+            name: http
+            protocol: TCP
+          - containerPort: 9443
+            name: https
+            protocol: TCP
+          # livenessProbe:
+          #   failureThreshold: 3
+          #   httpGet:
+          #     path: /healthz
+          #     port: 10254
+          #     scheme: HTTP
+          #   initialDelaySeconds: 10
+          #   periodSeconds: 10
+          #   successThreshold: 1
+          #   timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 9080
+            timeoutSeconds: 1
+          lifecycle:
+            # For alpine based image
+            # https://k8s.imroc.io/troubleshooting/cases/dns-lookup-5s-delay
+            # postStart:
+            #   exec:
+            #     command:
+            #     - /bin/sh
+            #     - -c
+            #     - "/bin/echo 'options single-request-reopen' >> /etc/resolv.conf"
+            preStop:
+              exec:
+                command:
+                - /bin/sh
+                - c
+                - sleep 30
+          # cpu core(s), 1 == 1000m
+          resources:
+            limits:
+              cpu: '2'
+            requests:
+              cpu: '50m'
+
+          volumeMounts:
+            - mountPath: /usr/local/apisix/conf/config.yaml
+              name: apisix-config-yaml-configmap
+              subPath: config.yaml
+            - mountPath: /etc/localtime
+              name: localtime
+              readOnly: true
+            # - mountPath: /usr/local/apisix/conf/nginx.conf
+            #   name: apisix-nginx-conf-configmap
+            #   subPath: nginx.conf
+            # - mountPath: /usr/local/openresty/openssl/ssl/openssl.cnf
+            #   name: apisix-openssl-cnf-configmap
+            #   subPath: openssl.cnf
+
+      volumes:
+        - configMap:
+            name: apisix-gw-config.yaml
+          name: apisix-config-yaml-configmap
+        - hostPath:
+            path: /etc/localtime
+            type: File
+          name: localtime
+        # - configMap:
+        #     name: apisix-gw-nginx.conf
+        #   name: apisix-nginx-conf-configmap
+        # - configMap:
+        #     name: apisix-gw-openssl.cnf.conf
+        #   name: apisix-openssl-cnf-configmap

--- a/kubernetes/service-aliyun-slb.yaml
+++ b/kubernetes/service-aliyun-slb.yaml
@@ -1,0 +1,61 @@
+# https://help.aliyun.com/document_detail/94925.html?spm=5176.2020520152.0.0.44ca16ddon5iJF
+apiVersion: v1
+kind: Service
+metadata:
+  name: apisix-gw-lb
+  # namespace: default
+  annotations:
+    # service.beta.kubernetes.io/alibaba-cloud-loadbalancer-additional-resource-tags: ""
+    #
+    # service.beta.kubernetes.io/alibaba-cloud-loadbalancer-AddressType: "intranet"
+    # service.beta.kubernetes.io/alibaba-cloud-loadbalancer-network-type: "vpc"
+    service.beta.kubernetes.io/alibaba-cloud-loadbalancer-force-override-listeners: "true"
+    service.beta.kubernetes.io/alibaba-cloud-loadbalancer-persistence-timeout: "1800"
+    service.beta.kubernetes.io/alibaba-cloud-loadbalancer-id: "lb-xx"
+    #
+    # http
+    # service.beta.kubernetes.io/alibaba-cloud-loadbalancer-cert-id: ''
+    # service.beta.kubernetes.io/alibaba-cloud-loadbalancer-protocol-port: 'https:443'
+    # service.beta.kubernetes.io/alibaba-cloud-loadbalancer-spec: "slb.s1.small"
+    # service.beta.kubernetes.io/alibaba-cloud-loadbalancer-forward-port
+    # http sticky-session
+    # service.beta.kubernetes.io/alibaba-cloud-loadbalancer-sticky-session: "on"
+    # service.beta.kubernetes.io/alibaba-cloud-loadbalancer-sticky-session-type: "insert"
+    # service.beta.kubernetes.io/alibaba-cloud-loadbalancer-cookie-timeout: "1800"
+    # service.beta.kubernetes.io/alibaba-cloud-loadbalancer-protocol-port: "http:80"
+    #
+    # health-check
+    service.beta.kubernetes.io/alibaba-cloud-loadbalancer-health-check-type: "tcp"
+    service.beta.kubernetes.io/alibaba-cloud-loadbalancer-health-check-connect-timeout: "4"
+    service.beta.kubernetes.io/alibaba-cloud-loadbalancer-healthy-threshold: "4"
+    service.beta.kubernetes.io/alibaba-cloud-loadbalancer-unhealthy-threshold: "4"
+    service.beta.kubernetes.io/alibaba-cloud-loadbalancer-health-check-interval: "6"
+    #
+    service.beta.kubernetes.io/alibaba-cloud-loadbalancer-scheduler: "wlc"
+    # ACL
+    # service.beta.kubernetes.io/alibaba-cloud-loadbalancer-acl-status: "on"
+    # service.beta.kubernetes.io/alibaba-cloud-loadbalancer-acl-id: "acl-xx"
+    # service.beta.kubernetes.io/alibaba-cloud-loadbalancer-acl-type: "white"
+    #
+    service.beta.kubernetes.io/alibaba-cloud-loadbalancer-remove-unscheduled-backend: "on"
+  labels:
+    app: apisix-gw
+spec:
+  selector:
+    app: apisix-gw
+  ports:
+    - protocol: TCP
+      port: 80
+      name: http
+      targetPort: 9080
+    - protocol: TCP
+      port: 443
+      name: https
+      targetPort: 9443
+    # - protocol: TCP
+    #   port: 9180
+    #   name: admin-port
+    #   targetPort: 9180
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  # sessionAffinity: ClientIP

--- a/kubernetes/service-aliyun-slb.yaml
+++ b/kubernetes/service-aliyun-slb.yaml
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # https://help.aliyun.com/document_detail/94925.html?spm=5176.2020520152.0.0.44ca16ddon5iJF
 apiVersion: v1
 kind: Service

--- a/kubernetes/service.yaml
+++ b/kubernetes/service.yaml
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/kubernetes/service.yaml
+++ b/kubernetes/service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: apisix-gw-lb
+  # namespace: default
+spec:
+  ports:
+  - name: http
+    port: 9080
+    protocol: TCP
+    targetPort: 9080
+  - name: https
+    port: 9443
+    protocol: TCP
+    targetPort: 9443
+  # - name: admin-port
+  #   port: 9180
+  #   protocol: TCP
+  #   targetPort: 9180
+  selector:
+    app: apisix-gw
+  type: NodePort
+  externalTrafficPolicy: Local
+  # sessionAffinity: None


### PR DESCRIPTION

### Summary

➜  kubernetes git:(k8s) tree .
.
├── README.md
├── apisix-gw-config-cm.yaml
├── deployment.yaml
├── service-aliyun-slb.yaml
└── service.yaml

### Full changelog

* add example .yaml resource files which support to run `Apache APISIX` on kubernetes
