### PR TITLE
bugfix: Fix issue of local variable 'routes' duplicate in create_radixtree_router function.

### DIFF
--- a/lua/apisix/http/router/radixtree_host_uri.lua
+++ b/lua/apisix/http/router/radixtree_host_uri.lua
@@ -113,10 +113,10 @@ local function create_radixtree_router(routes)
     end
 
     -- create router: only_uri_router
-    local routes = plugin.api_routes()
-    core.log.info("routes", core.json.delay_encode(routes, true))
+    local api_routes = plugin.api_routes()
+    core.log.info("api_routes", core.json.delay_encode(api_routes, true))
 
-    for _, route in ipairs(routes) do
+    for _, route in ipairs(api_routes) do
         if type(route) == "table" then
             core.table.insert(only_uri_routes, {
                 paths = route.uris or route.uri,


### PR DESCRIPTION
Fix issue of local variable 'routes' duplicate in create_radixtree_router function.

NOTE: Please read the Contributing.md guidelines before submitting your patch:

https://github.com/apache/incubator-apisix/blob/master/Contributing.md#how-to-add-a-new-feature-or-change-an-existing-one

### Summary

SUMMARY_HERE

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issues resolved

Fix #XXX
