### PR TITLE
bugfix: correct LUAJIT_DIR detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ ifeq ("$(wildcard /usr/local/openresty-debug/bin/openresty)", "")
 endif
 endif
 
-LUAJIT_DIR ?= $(shell ${OR_EXEC} -V 2>&1 | grep prefix | grep -Eo 'prefix=(.*?)/nginx' | grep -Eo '/.*/')luajit
+LUAJIT_DIR ?= $(shell ${OR_EXEC} -V 2>&1 | grep prefix | grep -Eo 'prefix=(.*)/nginx\s+--' | grep -Eo '/.*/')luajit
 
 ### help:             Show Makefile rules.
 .PHONY: help


### PR DESCRIPTION
grep doesn't support lazy match by default. To support it, `-P` should
be used instead of `-E`, see:
https://stackoverflow.com/a/5774431

However, we can achieve the same thing without lazy match.
Because OpenResty's not vanilla Nginx, there will be --option after the
executable.
