### PR TITLE
deletion: drop webdocket enable control in proxy-rewrite plugin

### DIFF
--- a/doc/plugins/proxy-rewrite-cn.md
+++ b/doc/plugins/proxy-rewrite-cn.md
@@ -29,7 +29,6 @@
 |uri             |可选| 转发到上游的新 `uri` 地址|
 |regex_uri       |可选| 转发到上游的新 `uri` 地址, 使用正则表达式匹配来自客户端的uri，当匹配成功后使用模板替换转发到上游的uri, 未匹配成功时将客户端请求的uri转发至上游。当`uri`和`regex_uri`同时存在时，`uri`优先被使用。例如：["^/iresty/(.*)/(.*)/(.*)","/$1-$2-$3"] 第一个元素代表匹配来自客户端请求的uri正则表达式，第二个元素代表匹配成功后转发到上游的uri模板|
 |host            |可选| 转发到上游的新 `host` 地址，例如：`iresty.com` |
-|enable_websocket|可选| 是否启用 `websocket`（布尔值），默认不启用|
 |headers         |可选| 转发到上游的新`headers`，可以设置多个。头信息如果存在将重写，不存在则添加。想要删除某个 header 的话，把对应的值设置为空字符串即可|
 
 ### 示例
@@ -47,7 +46,6 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1  -H 'X-API-KEY: edd1c9f034335f1
             "uri": "/test/home.html",
             "scheme": "http",
             "host": "iresty.com",
-            "enable_websocket": true,
             "headers": {
                 "X-Api-Version": "v1",
                 "X-Api-Engine": "apisix",

--- a/doc/plugins/proxy-rewrite.md
+++ b/doc/plugins/proxy-rewrite.md
@@ -37,7 +37,6 @@ upstream proxy info rewrite plugin.
 |uri             |optional| Upstream new `uri` forwarding address.|
 |regex_uri       |optional| Upstream new `uri` forwarding address. Use regular expression to match uri from client, when the match is successful, the uri template will be forwarded upstream. If the match is not successful, the uri from the client will be forwarded to the upstream. When `uri` and` regex_uri` are both exist, `uri` is used first. For example: [" ^/iresty/(.*)/(.*)/(.*)", "/$1-$2-$3"], the first element represents the matching regular expression and the second element represents the uri template that is forwarded to the upstream.|
 |host            |optional| Upstream new `host` forwarding address, example `iresty.com`. |
-|enable_websocket|optional| enable `websocket`(boolean), default `false`.|
 |headers         |optional| Forward to the new `headers` of the upstream, can set up multiple. If it exists, will rewrite the header, otherwise will add the header. You can set the corresponding value to an empty string to remove a header.|
 
 ## How To Enable
@@ -54,7 +53,6 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1  -H 'X-API-KEY: edd1c9f034335f1
             "uri": "/test/home.html",
             "scheme": "http",
             "host": "iresty.com",
-            "enable_websocket": true,
             "headers": {
                 "X-Api-Version": "v1",
                 "X-Api-Engine": "apisix",

--- a/lua/apisix/plugins/proxy-rewrite.lua
+++ b/lua/apisix/plugins/proxy-rewrite.lua
@@ -54,11 +54,6 @@ local schema = {
             type    = "string",
             enum    = {"http", "https"}
         },
-        enable_websocket = {
-            description = "enable websocket for request",
-            type        = "boolean",
-            default     = false
-        },
         headers = {
             description = "new headers for request",
             type = "object",
@@ -153,11 +148,6 @@ function _M.rewrite(conf, ctx)
         ctx.var.upstream_uri = upstream_uri .. "?" .. (ctx.var.args or "")
     else
         ctx.var.upstream_uri = upstream_uri
-    end
-
-    if conf.enable_websocket then
-        ctx.var.upstream_upgrade    = ctx.var.http_upgrade
-        ctx.var.upstream_connection = ctx.var.http_connection
     end
 
     if conf.headers_arr then

--- a/t/plugin/proxy-rewrite.t
+++ b/t/plugin/proxy-rewrite.t
@@ -99,7 +99,7 @@ done
                         "proxy-rewrite": {
                             "uri": "/test/add",
                             "scheme": "https",
-                            "host": "apisix.iresty.com",
+                            "host": "apisix.iresty.com"
                         }
                     },
                     "upstream": {
@@ -139,7 +139,7 @@ passed
                         "proxy-rewrite": {
                             "uri": "/test/update",
                             "scheme": "http",
-                            "host": "apisix.iresty.com",
+                            "host": "apisix.iresty.com"
                         }
                     },
                     "upstream": {
@@ -484,7 +484,7 @@ x-real-ip: 127.0.0.1
                  [[{
                         "plugins": {
                             "proxy-rewrite": {
-                                "uri": "/plugin_proxy_rewrite_args",
+                                "uri": "/plugin_proxy_rewrite_args"
                             }
                         },
                         "upstream": {
@@ -534,7 +534,7 @@ a: iresty
                  [[{
                         "plugins": {
                             "proxy-rewrite": {
-                                "uri": "/plugin_proxy_rewrite_args",
+                                "uri": "/plugin_proxy_rewrite_args"
                             }
                         },
                         "upstream": {

--- a/t/plugin/proxy-rewrite.t
+++ b/t/plugin/proxy-rewrite.t
@@ -42,7 +42,6 @@ __DATA__
             local ok, err = plugin.check_schema({
                 uri = '/apisix/home',
                 host = 'apisix.iresty.com',
-                enable_websocket = true,
                 scheme = 'http'
             })
             if not ok then
@@ -69,7 +68,6 @@ done
             local ok, err = plugin.check_schema({
                 uri = '/apisix/home',
                 host = 'apisix.iresty.com',
-                enable_websocket = true,
                 scheme = 'tcp'
             })
             if not ok then
@@ -102,7 +100,6 @@ done
                             "uri": "/test/add",
                             "scheme": "https",
                             "host": "apisix.iresty.com",
-                            "enable_websocket": true
                         }
                     },
                     "upstream": {
@@ -143,7 +140,6 @@ passed
                             "uri": "/test/update",
                             "scheme": "http",
                             "host": "apisix.iresty.com",
-                            "enable_websocket": false
                         }
                     },
                     "upstream": {
@@ -312,117 +308,7 @@ scheme: https
 
 
 
-=== TEST 10: set route(enable websocket)
---- config
-    location /t {
-        content_by_lua_block {
-            local t = require("lib.test_admin").test
-            local code, body = t('/apisix/admin/routes/1',
-                 ngx.HTTP_PUT,
-                 [[{
-                        "plugins": {
-                            "proxy-rewrite": {
-                                "uri": "/uri/plugin_proxy_rewrite",
-                                "enable_websocket": true
-                            }
-                        },
-                        "upstream": {
-                            "nodes": {
-                                "127.0.0.1:1980": 1
-                            },
-                            "type": "roundrobin"
-                        },
-                        "uri": "/hello"
-                }]]
-                )
-
-            if code >= 300 then
-                ngx.status = code
-            end
-            ngx.say(body)
-        }
-    }
---- request
-GET /t
---- response_body
-passed
---- no_error_log
-[error]
-
-
-
-=== TEST 11: enable websocket
---- request
-GET /hello HTTP/1.1
---- more_headers
-upgrade: default
-connection: close
---- response_body
-uri: /uri/plugin_proxy_rewrite
-host: localhost
-upgrade: default
-connection: close
-x-real-ip: 127.0.0.1
---- no_error_log
-[error]
-
-
-
-=== TEST 12: set route(disable websocket)
---- config
-    location /t {
-        content_by_lua_block {
-            local t = require("lib.test_admin").test
-            local code, body = t('/apisix/admin/routes/1',
-                 ngx.HTTP_PUT,
-                 [[{
-                        "plugins": {
-                            "proxy-rewrite": {
-                                "uri": "/uri/plugin_proxy_rewrite",
-                                "enable_websocket": false
-                            }
-                        },
-                        "upstream": {
-                            "nodes": {
-                                "127.0.0.1:1980": 1
-                            },
-                            "type": "roundrobin"
-                        },
-                        "uri": "/hello"
-                }]]
-                )
-
-            if code >= 300 then
-                ngx.status = code
-            end
-            ngx.say(body)
-        }
-    }
---- request
-GET /t
---- response_body
-passed
---- no_error_log
-[error]
-
-
-
-=== TEST 13: disable websocket
---- request
-GET /hello HTTP/1.1
---- more_headers
-upgrade: default
-connection: close
---- response_body
-uri: /uri/plugin_proxy_rewrite
-host: localhost
-x-real-ip: 127.0.0.1
---- no_error_log
-[error]
-
-
-
-=== TEST 14: set route(rewrite headers)
+=== TEST 10: set route(rewrite headers)
 --- config
     location /t {
         content_by_lua_block {
@@ -463,7 +349,7 @@ passed
 
 
 
-=== TEST 15: rewrite headers
+=== TEST 11: rewrite headers
 --- request
 GET /hello HTTP/1.1
 --- more_headers
@@ -478,7 +364,7 @@ x-real-ip: 127.0.0.1
 
 
 
-=== TEST 16: set route(add headers)
+=== TEST 12: set route(add headers)
 --- config
     location /t {
         content_by_lua_block {
@@ -519,7 +405,7 @@ passed
 
 
 
-=== TEST 17: add headers
+=== TEST 13: add headers
 --- request
 GET /hello HTTP/1.1
 --- response_body
@@ -532,7 +418,7 @@ x-real-ip: 127.0.0.1
 
 
 
-=== TEST 18: set route(rewrite empty headers)
+=== TEST 14: set route(rewrite empty headers)
 --- config
     location /t {
         content_by_lua_block {
@@ -573,7 +459,7 @@ passed
 
 
 
-=== TEST 19: rewrite empty headers
+=== TEST 15: rewrite empty headers
 --- request
 GET /hello HTTP/1.1
 --- more_headers
@@ -588,7 +474,7 @@ x-real-ip: 127.0.0.1
 
 
 
-=== TEST 20: set route(rewrite uri args)
+=== TEST 16: set route(rewrite uri args)
 --- config
     location /t {
         content_by_lua_block {
@@ -599,7 +485,6 @@ x-real-ip: 127.0.0.1
                         "plugins": {
                             "proxy-rewrite": {
                                 "uri": "/plugin_proxy_rewrite_args",
-                                "enable_websocket": false
                             }
                         },
                         "upstream": {
@@ -627,7 +512,7 @@ passed
 
 
 
-=== TEST 21: rewrite uri args
+=== TEST 17: rewrite uri args
 --- request
 GET /hello?q=apisix&a=iresty HTTP/1.1
 --- response_body
@@ -639,7 +524,7 @@ a: iresty
 
 
 
-=== TEST 22: set route(rewrite uri empty args)
+=== TEST 18: set route(rewrite uri empty args)
 --- config
     location /t {
         content_by_lua_block {
@@ -650,7 +535,6 @@ a: iresty
                         "plugins": {
                             "proxy-rewrite": {
                                 "uri": "/plugin_proxy_rewrite_args",
-                                "enable_websocket": false
                             }
                         },
                         "upstream": {
@@ -678,7 +562,7 @@ passed
 
 
 
-=== TEST 23: rewrite uri empty args
+=== TEST 19: rewrite uri empty args
 --- request
 GET /hello HTTP/1.1
 --- response_body
@@ -688,7 +572,7 @@ uri: /plugin_proxy_rewrite_args
 
 
 
-=== TEST 24: remove header
+=== TEST 20: remove header
 --- config
     location /t {
         content_by_lua_block {
@@ -730,7 +614,7 @@ passed
 
 
 
-=== TEST 25: remove header
+=== TEST 21: remove header
 --- request
 GET /hello HTTP/1.1
 --- more_headers
@@ -746,7 +630,7 @@ x-real-ip: 127.0.0.1
 
 
 
-=== TEST 26: set route(only using regex_uri)
+=== TEST 22: set route(only using regex_uri)
 --- config
     location /t {
         content_by_lua_block {
@@ -784,7 +668,7 @@ passed
 
 
 
-=== TEST 27: hit route(rewrite uri using regex_uri)
+=== TEST 23: hit route(rewrite uri using regex_uri)
 --- request
 GET /test/plugin/proxy/rewrite HTTP/1.1
 --- response_body
@@ -796,7 +680,7 @@ scheme: http
 
 
 
-=== TEST 28: hit route(404 not found)
+=== TEST 24: hit route(404 not found)
 --- request
 GET /test/not/found HTTP/1.1
 --- error_code: 404
@@ -805,7 +689,7 @@ GET /test/not/found HTTP/1.1
 
 
 
-=== TEST 29: set route(Using both uri and regex_uri)
+=== TEST 25: set route(Using both uri and regex_uri)
 --- config
     location /t {
         content_by_lua_block {
@@ -844,7 +728,7 @@ passed
 
 
 
-=== TEST 30: hit route(rewrite uri using uri & regex_uri property)
+=== TEST 26: hit route(rewrite uri using uri & regex_uri property)
 --- request
 GET /test/hello HTTP/1.1
 --- response_body
@@ -854,7 +738,7 @@ hello world
 
 
 
-=== TEST 31: set route(invalid regex_uri)
+=== TEST 27: set route(invalid regex_uri)
 --- config
     location /t {
         content_by_lua_block {
@@ -892,7 +776,7 @@ GET /t
 
 
 
-=== TEST 32: set route(invalid regex syntax for the first element)
+=== TEST 28: set route(invalid regex syntax for the first element)
 --- config
     location /t {
         content_by_lua_block {
@@ -932,7 +816,7 @@ qr/invalid regex_uri/
 
 
 
-=== TEST 33: set route(invalid regex syntax for the second element)
+=== TEST 29: set route(invalid regex syntax for the second element)
 --- config
     location /t {
         content_by_lua_block {
@@ -970,7 +854,7 @@ invalid capturing variable name found
 
 
 
-=== TEST 34: set route(invalid uri)
+=== TEST 30: set route(invalid uri)
 --- config
     location /t {
         content_by_lua_block {
@@ -1009,7 +893,7 @@ qr/failed to match pattern/
 
 
 
-=== TEST 35: wrong value of uri
+=== TEST 31: wrong value of uri
 --- config
     location /t {
         content_by_lua_block {


### PR DESCRIPTION
### Summary

remove websocket related code in proxy-rewrite plugin

since there is enable controller in the upstream module, there is no need to have websocket enable in this plugin.

And we need to mention this in the next release note

**Notice:**
the user need to transfer their websocket configuration from proxy-rewrite into upstream, if they enabled websocket proxy-rewrite plugin.


### Full changelog

*   doc/plugins/proxy-rewrite-cn.md
*   doc/plugins/proxy-rewrite.md
*   lua/apisix/plugins/proxy-rewrite.lua
*   t/plugin/proxy-rewrite.t


### Issues resolved
Fix https://github.com/apache/incubator-apisix/issues/1331