### PR TITLE
bugfix: installed lua file in folder `lua/apisix/utils` .

### DIFF
--- a/.travis/linux_apisix_current_luarocks_runner.sh
+++ b/.travis/linux_apisix_current_luarocks_runner.sh
@@ -54,10 +54,11 @@ script() {
     # apisix cli test
     sudo PATH=$PATH .travis/apisix_cli_test.sh
 
-    `cat /usr/local/apisix/logs/error.log | grep "\[error\]" > /tmp/error.log`
+    cat /usr/local/apisix/logs/error.log | grep '\[error\]' > /tmp/error.log
     if [ -s /tmp/error.log ]; then
-        echo "=====found error log=====\n"
-        cat /usr/local/apisix/logs/error.log && exit 1
+        echo "=====found error log====="
+        cat /usr/local/apisix/logs/error.log
+        exit 1
     fi
 
     sudo luarocks remove rockspec/apisix-master-0.rockspec

--- a/.travis/linux_apisix_current_luarocks_runner.sh
+++ b/.travis/linux_apisix_current_luarocks_runner.sh
@@ -54,7 +54,7 @@ script() {
     # apisix cli test
     sudo PATH=$PATH .travis/apisix_cli_test.sh
 
-    cat /usr/local/apisix/logs/error.log | grep '\[error\]' > /tmp/error.log
+    cat /usr/local/apisix/logs/error.log | grep '\[error\]' > /tmp/error.log | true
     if [ -s /tmp/error.log ]; then
         echo "=====found error log====="
         cat /usr/local/apisix/logs/error.log

--- a/.travis/linux_apisix_current_luarocks_runner.sh
+++ b/.travis/linux_apisix_current_luarocks_runner.sh
@@ -54,6 +54,12 @@ script() {
     # apisix cli test
     sudo PATH=$PATH .travis/apisix_cli_test.sh
 
+    `cat /usr/local/apisix/logs/error.log | grep "\[error\]" > /tmp/error.log`
+    if [ -s /tmp/error.log ]; then
+        echo "=====found error log=====\n"
+        cat /usr/local/apisix/logs/error.log && exit 1
+    fi
+
     sudo luarocks remove rockspec/apisix-master-0.rockspec
 }
 

--- a/.travis/linux_apisix_master_luarocks_runner.sh
+++ b/.travis/linux_apisix_master_luarocks_runner.sh
@@ -64,10 +64,10 @@ script() {
     # apisix cli test
     sudo PATH=$PATH .travis/apisix_cli_test.sh
 
-    `cat /usr/local/apisix/logs/error.log | grep "\[error\]" > /tmp/error.log`
+    cat /usr/local/apisix/logs/error.log | grep '\[error\]' > /tmp/error.log
     if [ -s /tmp/error.log ]; then
-        echo "=====found error log=====\n"
-        cat /usr/local/apisix/logs/error.log && exit 1
+        echo "=====found error log====="
+        cat /usr/local/apisix/logs/error.log
     fi
 
     sudo luarocks remove rockspec/apisix-master-0.rockspec

--- a/.travis/linux_apisix_master_luarocks_runner.sh
+++ b/.travis/linux_apisix_master_luarocks_runner.sh
@@ -64,6 +64,12 @@ script() {
     # apisix cli test
     sudo PATH=$PATH .travis/apisix_cli_test.sh
 
+    `cat /usr/local/apisix/logs/error.log | grep "\[error\]" > /tmp/error.log`
+    if [ -s /tmp/error.log ]; then
+        echo "=====found error log=====\n"
+        cat /usr/local/apisix/logs/error.log && exit 1
+    fi
+
     sudo luarocks remove rockspec/apisix-master-0.rockspec
 }
 

--- a/.travis/linux_apisix_master_luarocks_runner.sh
+++ b/.travis/linux_apisix_master_luarocks_runner.sh
@@ -64,7 +64,7 @@ script() {
     # apisix cli test
     sudo PATH=$PATH .travis/apisix_cli_test.sh
 
-    cat /usr/local/apisix/logs/error.log | grep '\[error\]' > /tmp/error.log
+    cat /usr/local/apisix/logs/error.log | grep '\[error\]' > /tmp/error.log | true
     if [ -s /tmp/error.log ]; then
         echo "=====found error log====="
         cat /usr/local/apisix/logs/error.log

--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,9 @@ install:
 	$(INSTALL) -d $(INST_LUADIR)/apisix/lua/apisix/stream/router
 	$(INSTALL) lua/apisix/stream/router/*.lua $(INST_LUADIR)/apisix/lua/apisix/stream/router/
 
+	$(INSTALL) -d $(INST_LUADIR)/apisix/lua/apisix/utils
+	$(INSTALL) lua/apisix/utils/*.lua $(INST_LUADIR)/apisix/lua/apisix/utils/
+
 	$(INSTALL) README.md $(INST_CONFDIR)/README.md
 	$(INSTALL) bin/apisix $(INST_BINDIR)/apisix
 

--- a/utils/check-lua-code-style.sh
+++ b/utils/check-lua-code-style.sh
@@ -32,7 +32,7 @@ luacheck -q lua
     lua/apisix/plugins/limit-count/*.lua > \
     /tmp/check.log 2>&1 || (cat /tmp/check.log && exit 1)
 
-count=`grep -E ".lua:[0-9]+:" /tmp/check.log -c || true`
+count=`grep -E ".lua:[0-9]+:" /tmp/check.log -c | true`
 
 if [ $count -ne 0 ]
 then


### PR DESCRIPTION
If we install the latest APISIX by luarocks, we'll get the error log like this:
 
https://travis-ci.org/github/apache/incubator-apisix/jobs/667148749#L1882

This bug is related to the commit: https://github.com/apache/incubator-apisix/commit/429f0165c202035b18b4437a84c6edc9007fc440#diff-cf73ae5e62361600170ba3c1ffab549e

```
2020/03/26 09:34:48 [error] 10333#10333: *1 [lua] plugin.lua:66: load_plugin(): failed to load plugin [kafka-logger] err: ...share/lua/5.1/apisix/lua/apisix/plugins/kafka-logger.lua:18: module 'apisix.utils.log-util' not found:
	no field package.preload['apisix.utils.log-util']
	no file '/usr/local/apisix//deps/share/lua/5.1/apisix/utils/log-util.lua'
	no file '/usr/share/lua/5.1/apisix/lua/apisix/utils/log-util.lua'
	no file '/usr/local/share/lua/5.1/apisix/lua/apisix/utils/log-util.lua'
	no file '/usr/local/apisix//deps/share/lua/5.1/apisix/lua/apisix/utils/log-util.lua'
	no file '/usr/local/apisix/lua/apisix/utils/log-util.lua'
	no file '/usr/local/openresty-debug/site/lualib/apisix/utils/log-util.ljbc'
	no file '/usr/local/openresty-debug/site/lualib/apisix/utils/log-util/init.ljbc'
	no file '/usr/local/openresty-debug/lualib/apisix/utils/log-util.ljbc'
	no file '/usr/local/openresty-debug/lualib/apisix/utils/log-util/init.ljbc'
```