### PR TITLE
feature: merge upstream tengine (2.3.2 < version < 2.3.3) patches

### DIFF
--- a/.travis/linux_tengine_runner.sh
+++ b/.travis/linux_tengine_runner.sh
@@ -107,7 +107,7 @@ tengine_install() {
     wget -P patches https://raw.githubusercontent.com/openresty/openresty/master/patches/nginx-1.17.4-upstream_timeout_fields.patch
     wget -P patches https://raw.githubusercontent.com/totemofwolf/openresty/master/patches/tengine-2.3.2-privileged_agent_process.patch
     wget -P patches https://raw.githubusercontent.com/totemofwolf/tengine/feature/patches/tengine-2.3.2-delete_unused_variable.patch
-    # wget -P patches https://raw.githubusercontent.com/totemofwolf/tengine/feature/patches/tengine-2.3.2-keepalive_post_request_status.patch
+    wget -P patches https://raw.githubusercontent.com/totemofwolf/tengine/feature/patches/tengine-2.3.2-keepalive_post_request_status.patch
     # wget -P patches https://raw.githubusercontent.com/totemofwolf/tengine/feature/patches/tengine-2.3.2-tolerate_backslash_zero_in_uri.patch
 
     cd bundle/tengine-2.3.2
@@ -137,7 +137,7 @@ tengine_install() {
     patch -p1 < ../../patches/nginx-1.17.4-upstream_timeout_fields.patch
     patch -p1 < ../../patches/tengine-2.3.2-privileged_agent_process.patch
     patch -p1 < ../../patches/tengine-2.3.2-delete_unused_variable.patch
-    # patch -p1 < ../../patches/tengine-2.3.2-keepalive_post_request_status.patch
+    patch -p1 < ../../patches/tengine-2.3.2-keepalive_post_request_status.patch
     # patch -p1 < ../../patches/tengine-2.3.2-tolerate_backslash_zero_in_uri.patch
 
     cd -

--- a/.travis/linux_tengine_runner.sh
+++ b/.travis/linux_tengine_runner.sh
@@ -108,7 +108,7 @@ tengine_install() {
     wget -P patches https://raw.githubusercontent.com/totemofwolf/openresty/master/patches/tengine-2.3.2-privileged_agent_process.patch
     wget -P patches https://raw.githubusercontent.com/totemofwolf/tengine/feature/patches/tengine-2.3.2-delete_unused_variable.patch
     wget -P patches https://raw.githubusercontent.com/totemofwolf/tengine/feature/patches/tengine-2.3.2-keepalive_post_request_status.patch
-    # wget -P patches https://raw.githubusercontent.com/totemofwolf/tengine/feature/patches/tengine-2.3.2-tolerate_backslash_zero_in_uri.patch
+    wget -P patches https://raw.githubusercontent.com/totemofwolf/tengine/feature/patches/tengine-2.3.2-tolerate_backslash_zero_in_uri.patch
 
     cd bundle/tengine-2.3.2
     patch -p1 < ../../patches/nginx-1.17.4-always_enable_cc_feature_tests.patch
@@ -138,7 +138,7 @@ tengine_install() {
     patch -p1 < ../../patches/tengine-2.3.2-privileged_agent_process.patch
     patch -p1 < ../../patches/tengine-2.3.2-delete_unused_variable.patch
     patch -p1 < ../../patches/tengine-2.3.2-keepalive_post_request_status.patch
-    # patch -p1 < ../../patches/tengine-2.3.2-tolerate_backslash_zero_in_uri.patch
+    patch -p1 < ../../patches/tengine-2.3.2-tolerate_backslash_zero_in_uri.patch
 
     cd -
     # patching end

--- a/.travis/linux_tengine_runner.sh
+++ b/.travis/linux_tengine_runner.sh
@@ -106,6 +106,9 @@ tengine_install() {
     wget -P patches https://raw.githubusercontent.com/openresty/openresty/master/patches/nginx-1.17.4-upstream_pipelining.patch
     wget -P patches https://raw.githubusercontent.com/openresty/openresty/master/patches/nginx-1.17.4-upstream_timeout_fields.patch
     wget -P patches https://raw.githubusercontent.com/totemofwolf/openresty/master/patches/tengine-2.3.2-privileged_agent_process.patch
+    wget -P patches https://raw.githubusercontent.com/totemofwolf/tengine/feature/patches/tengine-2.3.2-delete_unused_variable.patch
+    # wget -P patches https://raw.githubusercontent.com/totemofwolf/tengine/feature/patches/tengine-2.3.2-keepalive_post_request_status.patch
+    # wget -P patches https://raw.githubusercontent.com/totemofwolf/tengine/feature/patches/tengine-2.3.2-tolerate_backslash_zero_in_uri.patch
 
     cd bundle/tengine-2.3.2
     patch -p1 < ../../patches/nginx-1.17.4-always_enable_cc_feature_tests.patch
@@ -133,6 +136,9 @@ tengine_install() {
     patch -p1 < ../../patches/nginx-1.17.4-upstream_pipelining.patch
     patch -p1 < ../../patches/nginx-1.17.4-upstream_timeout_fields.patch
     patch -p1 < ../../patches/tengine-2.3.2-privileged_agent_process.patch
+    patch -p1 < ../../patches/tengine-2.3.2-delete_unused_variable.patch
+    # patch -p1 < ../../patches/tengine-2.3.2-keepalive_post_request_status.patch
+    # patch -p1 < ../../patches/tengine-2.3.2-tolerate_backslash_zero_in_uri.patch
 
     cd -
     # patching end


### PR DESCRIPTION

### Summary

feature: merge upstream tengine (2.3.2 < version < 2.3.3) patches

### Full changelog

* modules/mod_dubbo/utils/utils.cc
* modules/ngx_http_upstream_keepalive_module/ngx_http_upstream_keepalive_module.c
* src/http/ngx_http_core_module.c

### Issues resolved

