### PR TITLE
bugfix: remove misc `--add-dynamic-module` for tengine branch ci test cases

### DIFF
--- a/.travis/linux_tengine_runner.sh
+++ b/.travis/linux_tengine_runner.sh
@@ -176,19 +176,19 @@ tengine_install() {
         --add-module=bundle/tengine-2.3.2/modules/mod_dubbo \
         --add-module=bundle/tengine-2.3.2/modules/ngx_multi_upstream_module \
         --add-module=bundle/tengine-2.3.2/modules/mod_config \
-        --add-dynamic-module=bundle/tengine-2.3.2/modules/ngx_http_concat_module \
-        --add-dynamic-module=bundle/tengine-2.3.2/modules/ngx_http_footer_filter_module \
-        --add-dynamic-module=bundle/tengine-2.3.2/modules/ngx_http_proxy_connect_module \
-        --add-dynamic-module=bundle/tengine-2.3.2/modules/ngx_http_reqstat_module \
+        --add-module=bundle/tengine-2.3.2/modules/ngx_http_concat_module \
+        --add-module=bundle/tengine-2.3.2/modules/ngx_http_footer_filter_module \
+        --add-module=bundle/tengine-2.3.2/modules/ngx_http_proxy_connect_module \
+        --add-module=bundle/tengine-2.3.2/modules/ngx_http_reqstat_module \
         --add-dynamic-module=bundle/tengine-2.3.2/modules/ngx_http_slice_module \
         --add-dynamic-module=bundle/tengine-2.3.2/modules/ngx_http_sysguard_module \
-        --add-dynamic-module=bundle/tengine-2.3.2/modules/ngx_http_trim_filter_module \
+        --add-module=bundle/tengine-2.3.2/modules/ngx_http_trim_filter_module \
         --add-dynamic-module=bundle/tengine-2.3.2/modules/ngx_http_upstream_check_module \
         --add-dynamic-module=bundle/tengine-2.3.2/modules/ngx_http_upstream_consistent_hash_module \
-        --add-dynamic-module=bundle/tengine-2.3.2/modules/ngx_http_upstream_dynamic_module \
-        --add-dynamic-module=bundle/tengine-2.3.2/modules/ngx_http_upstream_dyups_module \
+        --add-module=bundle/tengine-2.3.2/modules/ngx_http_upstream_dynamic_module \
+        --add-module=bundle/tengine-2.3.2/modules/ngx_http_upstream_dyups_module \
         --add-dynamic-module=bundle/tengine-2.3.2/modules/ngx_http_upstream_session_sticky_module \
-        --add-dynamic-module=bundle/tengine-2.3.2/modules/ngx_http_user_agent_module \
+        --add-module=bundle/tengine-2.3.2/modules/ngx_http_user_agent_module \
         --add-dynamic-module=bundle/tengine-2.3.2/modules/ngx_slab_stat \
         > build.log 2>&1 || (cat build.log && exit 1)
 

--- a/.travis/linux_tengine_runner.sh
+++ b/.travis/linux_tengine_runner.sh
@@ -107,7 +107,7 @@ tengine_install() {
     wget -P patches https://raw.githubusercontent.com/openresty/openresty/master/patches/nginx-1.17.4-upstream_timeout_fields.patch
     wget -P patches https://raw.githubusercontent.com/totemofwolf/openresty/master/patches/tengine-2.3.2-privileged_agent_process.patch
     wget -P patches https://raw.githubusercontent.com/totemofwolf/tengine/feature/patches/tengine-2.3.2-delete_unused_variable.patch
-    # wget -P patches https://raw.githubusercontent.com/totemofwolf/tengine/feature/patches/tengine-2.3.2-keepalive_post_request_status.patch
+    wget -P patches https://raw.githubusercontent.com/totemofwolf/tengine/feature/patches/tengine-2.3.2-keepalive_post_request_status.patch
     # wget -P patches https://raw.githubusercontent.com/totemofwolf/tengine/feature/patches/tengine-2.3.2-tolerate_backslash_zero_in_uri.patch
 
     cd bundle/tengine-2.3.2
@@ -137,7 +137,7 @@ tengine_install() {
     patch -p1 < ../../patches/nginx-1.17.4-upstream_timeout_fields.patch
     patch -p1 < ../../patches/tengine-2.3.2-privileged_agent_process.patch
     patch -p1 < ../../patches/tengine-2.3.2-delete_unused_variable.patch
-    # patch -p1 < ../../patches/tengine-2.3.2-keepalive_post_request_status.patch
+    patch -p1 < ../../patches/tengine-2.3.2-keepalive_post_request_status.patch
     # patch -p1 < ../../patches/tengine-2.3.2-tolerate_backslash_zero_in_uri.patch
 
     cd -

--- a/.travis/linux_tengine_runner.sh
+++ b/.travis/linux_tengine_runner.sh
@@ -108,7 +108,7 @@ tengine_install() {
     wget -P patches https://raw.githubusercontent.com/totemofwolf/openresty/master/patches/tengine-2.3.2-privileged_agent_process.patch
     wget -P patches https://raw.githubusercontent.com/totemofwolf/tengine/feature/patches/tengine-2.3.2-delete_unused_variable.patch
     wget -P patches https://raw.githubusercontent.com/totemofwolf/tengine/feature/patches/tengine-2.3.2-keepalive_post_request_status.patch
-    # wget -P patches https://raw.githubusercontent.com/totemofwolf/tengine/feature/patches/tengine-2.3.2-tolerate_backslash_zero_in_uri.patch
+    wget -P patches https://raw.githubusercontent.com/totemofwolf/tengine/feature/patches/tengine-2.3.2-tolerate_backslash_zero_in_uri.patch
 
     cd bundle/tengine-2.3.2
     patch -p1 < ../../patches/nginx-1.17.4-always_enable_cc_feature_tests.patch
@@ -138,7 +138,7 @@ tengine_install() {
     patch -p1 < ../../patches/tengine-2.3.2-privileged_agent_process.patch
     patch -p1 < ../../patches/tengine-2.3.2-delete_unused_variable.patch
     patch -p1 < ../../patches/tengine-2.3.2-keepalive_post_request_status.patch
-    # patch -p1 < ../../patches/tengine-2.3.2-tolerate_backslash_zero_in_uri.patch
+    patch -p1 < ../../patches/tengine-2.3.2-tolerate_backslash_zero_in_uri.patch
 
     cd -
     # patching end

--- a/.travis/linux_tengine_runner.sh
+++ b/.travis/linux_tengine_runner.sh
@@ -106,6 +106,9 @@ tengine_install() {
     wget -P patches https://raw.githubusercontent.com/openresty/openresty/master/patches/nginx-1.17.4-upstream_pipelining.patch
     wget -P patches https://raw.githubusercontent.com/openresty/openresty/master/patches/nginx-1.17.4-upstream_timeout_fields.patch
     wget -P patches https://raw.githubusercontent.com/totemofwolf/openresty/master/patches/tengine-2.3.2-privileged_agent_process.patch
+    wget -P patches https://raw.githubusercontent.com/totemofwolf/tengine/feature/patches/tengine-2.3.2-delete_unused_variable.patch
+    # wget -P patches https://raw.githubusercontent.com/totemofwolf/tengine/feature/patches/tengine-2.3.2-keepalive_post_request_status.patch
+    # wget -P patches https://raw.githubusercontent.com/totemofwolf/tengine/feature/patches/tengine-2.3.2-tolerate_backslash_zero_in_uri.patch
 
     cd bundle/tengine-2.3.2
     patch -p1 < ../../patches/nginx-1.17.4-always_enable_cc_feature_tests.patch
@@ -133,6 +136,9 @@ tengine_install() {
     patch -p1 < ../../patches/nginx-1.17.4-upstream_pipelining.patch
     patch -p1 < ../../patches/nginx-1.17.4-upstream_timeout_fields.patch
     patch -p1 < ../../patches/tengine-2.3.2-privileged_agent_process.patch
+    patch -p1 < ../../patches/tengine-2.3.2-delete_unused_variable.patch
+    # patch -p1 < ../../patches/tengine-2.3.2-keepalive_post_request_status.patch
+    # patch -p1 < ../../patches/tengine-2.3.2-tolerate_backslash_zero_in_uri.patch
 
     cd -
     # patching end


### PR DESCRIPTION
### Summary

remove misc `--add-dynamic-module` for tengine since we do not set `load_module` in nginx.conf

### Full changelog

* .travis/linux_tengine_runner.sh

### Issues resolved

