### PR TITLE
feature: expose a health check uri for external monitor system

### DIFF
--- a/bin/apisix
+++ b/bin/apisix
@@ -380,6 +380,15 @@ http {
         }
         {% end %}
 
+
+        {% if health_status and health_status.uri then %}
+        location ={*health_status.uri*} {
+            {%if health_status.content then%}
+            echo "{*health_status.content*}";
+            {% end %}
+        }
+        {% end %}
+
         ssl_certificate_by_lua_block {
             apisix.http_ssl_phase()
         }

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -49,6 +49,9 @@ apisix:
   #    disk_size: 1G
   #    disk_path: "/tmp/disk_cache_two"
   #    cache_levels: "1:2"
+  health_status:                  # Expose a uri to client check the health status of APISIX
+    uri: "/apisix/health_status"  # The uri of health
+    content: "ok"                 # Content return to client for health check uri
 
   # allow_admin:                  # http://nginx.org/en/docs/http/ngx_http_access_module.html#allow
   #   - 127.0.0.0/24              # If we don't set any IP list, then any IP access is allowed by default.


### PR DESCRIPTION
### Summary

in some scenario, we need monitor whether  the APISIX server is alive or not, so that we need a URI output some content specified by System maintainer. the the health check URI will usually setup in some  remote monitor system.

### Full changelog

* bin/apisix
* config/config.yaml

