### PR TITLE
travis: When the error message is found, set the exit code to 1.

### DIFF
--- a/.travis/linux_apisix_master_luarocks_runner.sh
+++ b/.travis/linux_apisix_master_luarocks_runner.sh
@@ -70,6 +70,7 @@ script() {
     if [ -s /tmp/error.log ]; then
         echo "=====found error log====="
         cat /usr/local/apisix/logs/error.log
+        exit 1
     fi
 
     sudo luarocks remove rockspec/apisix-master-0.rockspec


### PR DESCRIPTION
we need to catch the error case.