### PR TITLE
doc style fix:  fix doc style of how-to-build-cn.md and how-to-build.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,12 +26,12 @@
 - [0.7.0](#070)
 - [0.6.0](#060)
 
-
 ## 1.1.0
 
 This release is mainly to strengthen the stability of the code and add more documentation.
 
 ### Core
+
 - always specify perl include path when runing test cases. [#1097](https://github.com/apache/incubator-apisix/pull/1097)
 - Feature: Add support for PROXY Protocol. [#1113](https://github.com/apache/incubator-apisix/pull/1113)
 - enhancement: add verify command to verify apisix configuration(nginx.conf). [#1112](https://github.com/apache/incubator-apisix/pull/1112)
@@ -41,6 +41,7 @@ This release is mainly to strengthen the stability of the code and add more docu
 - Modify bin/apisix to support the SO_REUSEPORT. [#1085](https://github.com/apache/incubator-apisix/pull/1085)
 
 ### Doc
+
 - doc: add link to download grafana meta data. [#1119](https://github.com/apache/incubator-apisix/pull/1119)
 - doc: Update README.md. [#1118](https://github.com/apache/incubator-apisix/pull/1118)
 - doc: doc: add wolf-rbac plugin. [#1116](https://github.com/apache/incubator-apisix/pull/1116)
@@ -53,21 +54,23 @@ This release is mainly to strengthen the stability of the code and add more docu
 - Update architecture-design-cn.md. [#1065](https://github.com/apache/incubator-apisix/pull/1065)
 
 ### CI
+
 - ci: remove patch which is no longer necessary and removed in the upst. [#1090](https://github.com/apache/incubator-apisix/pull/1090)
 - fix path error when install with luarocks. [#1068](https://github.com/apache/incubator-apisix/pull/1068)
 - travis: run a apisix instance which intalled by luarocks. [#1063](https://github.com/apache/incubator-apisix/pull/1063)
 
 ### Plugins
+
 - feature: Add wolf rbac plugin. [#1095](https://github.com/apache/incubator-apisix/pull/1095)
 - Adding UDP logger plugin. [#1070](https://github.com/apache/incubator-apisix/pull/1070)
 - enhancement: using internal request instead of external request in node-status plugin. [#1109](https://github.com/apache/incubator-apisix/pull/1109)
-
 
 ## 1.0.0
 
 This release is mainly to strengthen the stability of the code and add more documentation.
 
 ### Core
+
 - :sunrise: Support routing priority. You can match different upstream services based on conditions such as header, args, priority, etc. under the same URI. [#998](https://github.com/apache/incubator-apisix/pull/998)
 - When no route is matched, an error message is returned. To distinguish it from other 404 requests. [#1013](https://github.com/apache/incubator-apisix/pull/1013)
 - The address of the dashboard `/apisix/admin` supports CORS. [#982](https://github.com/apache/incubator-apisix/pull/982)
@@ -78,6 +81,7 @@ This release is mainly to strengthen the stability of the code and add more docu
 - Remove the nginx.conf file from the code repository. It is automatically generated every time and cannot be modified manually. [#974](https://github.com/apache/incubator-apisix/pull/974)
 
 ### Doc
+
 - Added documentation on how to customize development plugins. [#909](https://github.com/apache/incubator-apisix/pull/909)
 - fixed example's bugs in the serverless plugin documentation. [#1006](https://github.com/apache/incubator-apisix/pull/1006)
 - Added documentation for using the Oauth plugin. [#987](https://github.com/apache/incubator-apisix/pull/987)
@@ -86,9 +90,9 @@ This release is mainly to strengthen the stability of the code and add more docu
 - Added documentation on how to enable the MQTT plugin. [#916](https://github.com/apache/incubator-apisix/pull/916)
 
 ### Test case
+
 - Add test cases for key-auth plugin under normal circumstances. [#964](https://github.com/apache/incubator-apisix/pull/964/)
 - Added tests for gRPC transcode pb options. [#920](https://github.com/apache/incubator-apisix/pull/920)
-
 
 ## 0.9.0
 
@@ -96,6 +100,7 @@ This release brings many new features, such as support for running APISIX with T
 an advanced debugging mode that is more developer friendly, and a new URI redirection plugin.
 
 ### Core
+
 - :sunrise: Supported to run APISIX with tengine. [#683](https://github.com/apache/incubator-apisix/pull/683)
 - :sunrise: Enabled HTTP2 and supported to set ssl_protocols. [#663](https://github.com/apache/incubator-apisix/pull/663)
 - :sunrise: Advanced Debug Mode, Target module function's input arguments or returned value would be printed once this option is enabled. [#614](https://github.com/apache/incubator-apisix/pull/641)
@@ -103,17 +108,20 @@ an advanced debugging mode that is more developer friendly, and a new URI redire
 - Removed router R3 [#725](https://github.com/apache/incubator-apisix/pull/725)
 
 ### Plugins
+
 - [Redirect URI](https://github.com/apache/incubator-apisix/blob/master/doc/plugins/redirect.md): Redirect URI plugin. [#732](https://github.com/apache/incubator-apisix/pull/732)
 - [Proxy Rewrite](https://github.com/apache/incubator-apisix/blob/master/doc/plugins/proxy-rewrite.md): Supported remove `header` feature. [#658](https://github.com/apache/incubator-apisix/pull/658)
 - [Limit Count](https://github.com/apache/incubator-apisix/blob/master/doc/plugins/limit-count.md): Supported global limit count with `Redis Server`.[#624](https://github.com/apache/incubator-apisix/pull/624)
 
 ### lua-resty-*
+
 - lua-resty-radixtree
-    - Support for `host + uri` as an index.
+  - Support for `host + uri` as an index.
 - lua-resty-jsonschema
-    - This extension is a JSON data validator that replaces the existing `lua-rapidjson` extension.
+  - This extension is a JSON data validator that replaces the existing `lua-rapidjson` extension.
 
 ### Bugfix
+
 - key-auth plugin cannot run accurately in the case of multiple consumers. [#826](https://github.com/apache/incubator-apisix/pull/826)
 - Exported schema for plugin serverless. [#787](https://github.com/apache/incubator-apisix/pull/787)
 - Discard args of uri when using proxy-write plugin [#642](https://github.com/apache/incubator-apisix/pull/642)
@@ -123,16 +131,18 @@ an advanced debugging mode that is more developer friendly, and a new URI redire
 - Support more built-in parameters when set chash balancer. [#775](https://github.com/apache/incubator-apisix/pull/775)
 
 ### Dependencies
+
 - Replace the `lua-rapidjson` module with `lua-resty-jsonschema` global,  `lua-resty-jsonschema` is faster and easier to compile.
 
-
 ## 0.8.0
+
 > Released on 2019/09/30
 
 This release brings many new features, such as stream proxy, support MQTT protocol proxy,
 and support for ARM platform, and proxy rewrite plugin.
 
 ### Core
+
 - :sunrise: **[support stand-alone mode](https://github.com/apache/incubator-apisix/blob/master/doc/stand-alone-cn.md)**: using yaml to update configurations of APISIX, more friendly to kubernetes. [#464](https://github.com/apache/incubator-apisix/pull/464)
 - :sunrise: **[support stream proxy](https://github.com/apache/incubator-apisix/blob/master/doc/stream-proxy.md)**. [#513](https://github.com/apache/incubator-apisix/pull/513)
 - :sunrise: support consumer bind plugins. [#544](https://github.com/apache/incubator-apisix/pull/544)
@@ -140,29 +150,32 @@ and support for ARM platform, and proxy rewrite plugin.
 - ignored upstream node when it's weight is 0. [#536](https://github.com/apache/incubator-apisix/pull/536)
 
 ### Plugins
+
 - :sunrise: **[MQTT Proxy](https://github.com/apache/incubator-apisix/blob/master/doc/plugins/mqtt-proxy.md)**: support to load balance MQTT by `client_id`, both support MQTT 3.1 and 5.0. [#513](https://github.com/apache/incubator-apisix/pull/513)
 - [proxy-rewrite](https://github.com/apache/incubator-apisix/blob/master/doc/plugins/proxy-rewrite.md): rewrite uri,
  schema, host for upstream. [#594](https://github.com/apache/incubator-apisix/pull/594)
 
 ### ARM
+
 - :sunrise: **APISIX can run normally under Ubuntu 18.04 of ARM64 architecture**, so you can use APISIX as IoT gateway with MQTT plugin.
 
 ### lua-resty-*
-- lua-resty-ipmatcher
-    - support IPv6
-    - IP white/black list, route.
-- lua-resty-radixtree
-    - allow to specify multiple host, remote_addr and uri.
-    - allow to define user-function to filter request.
-    - use `lua-resty-ipmatcher` instead of `lua-resty-iputils`, `lua-resty-ipmatcher` matches fast and support IPv6.
 
+- lua-resty-ipmatcher
+  - support IPv6
+  - IP white/black list, route.
+- lua-resty-radixtree
+  - allow to specify multiple host, remote_addr and uri.
+  - allow to define user-function to filter request.
+  - use `lua-resty-ipmatcher` instead of `lua-resty-iputils`, `lua-resty-ipmatcher` matches fast and support IPv6.
 
 ### Bugfix
+
 - healthcheck: the checker name is wrong if APISIX works under multiple processes. [#568](https://github.com/apache/incubator-apisix/issues/568)
 
 ### Dependencies
-- removed `lua-tinyyaml` from source code base, and install through Luarocks.
 
+- removed `lua-tinyyaml` from source code base, and install through Luarocks.
 
 ## 0.7.0
 
@@ -171,6 +184,7 @@ and support for ARM platform, and proxy rewrite plugin.
 This release brings many new features, such as IP black and white list, gPRC protocol transcoding, IPv6, IdP (identity provider) services, serverless, Change the default route to radix tree (**not downward compatible**), and more.
 
 ### Core
+
 - :sunrise: **[gRPC transcoding](https://github.com/apache/incubator-apisix/blob/master/doc/plugins/grpc-transcoding.md)**: supports protocol transcoding so that clients can access your gRPC API by using HTTP/JSON. [#395](https://github.com/apache/incubator-apisix/issues/395)
 - :sunrise: **[radix tree router](https://github.com/apache/incubator-apisix/blob/master/doc/router-radixtree.md)**: The radix tree is used as the default router implementation. It supports the uri, host, cookie, request header, request parameters, Nginx built-in variables, etc. as the routing conditions, and supports common operators such as equal, greater than, less than, etc., more powerful and flexible.**IMPORTANT: This change is not downward compatible. All users who use historical versions need to manually modify their routing to work properly.** [#414](https://github.com/apache/incubator-apisix/issues/414)
 - Dynamic upstream supports more parameters, you can specify the upstream uri and host, and whether to enable websocket. [#451](https://github.com/apache/incubator-apisix/pull/451)
@@ -178,23 +192,25 @@ This release brings many new features, such as IP black and white list, gPRC pro
 - Routing support IPv6. [#331](https://github.com/apache/incubator-apisix/issues/331)
 
 ### Plugins
+
 - :sunrise: **[serverless](https://github.com/apache/incubator-apisix/blob/master/doc/plugins/serverless.md)**: With serverless support, users can dynamically run any Lua function on a gateway node. Users can also use this feature as a lightweight plugin.[#86](https://github.com/apache/incubator-apisix/pull/86)
 - :sunrise: **support IdP**: Support external authentication services, such as Auth0, okta, etc., users can use this to connect to Oauth2.0 and other authentication methods. [#447](https://github.com/apache/incubator-apisix/pull/447)
 - [rate limit](https://github.com/apache/incubator-apisix/blob/master/doc/plugins/limit-conn.md): Support for more restricted keys, such as `X-Forwarded-For` and `X-Real-IP`, and allows users to use Nginx variables, request headers, and request parameters as keys. [#228](https://github.com/apache/incubator-apisix/issues/228)
 - [IP black and white list](https://github.com/apache/incubator-apisix/blob/master/doc/plugins/ip-restriction.md) Support IP black and white list for security. [#398](https://github.com/apache/incubator-apisix/pull/398)
 
 ### CLI
+
 - Add the `version` directive to get the version number of APISIX. [#420](https://github.com/apache/incubator-apisix/issues/420)
 
 ### Admin
+
 - The `PATCH` API is supported and can be modified individually for a configuration without submitting the entire configuration. [#365](https://github.com/apache/incubator-apisix/pull/365)
 
 ### Dashboard
+
 - :sunrise: **Add the online version of the dashboard**，users can [experience APISIX](http://apisix.iresty.com/) without install. [#374](https://github.com/apache/incubator-apisix/issues/374)
 
-
 [Back to TOC](#table-of-contents)
-
 
 ## 0.6.0
 
@@ -203,6 +219,7 @@ This release brings many new features, such as IP black and white list, gPRC pro
 This release brings many new features such as health check and circuit breaker, debug mode, opentracing and JWT auth. And add **built-in dashboard**.
 
 ### Core
+
 - :sunrise: **[Health Check and Circuit Breaker](https://github.com/apache/incubator-apisix/blob/master/doc/health-check.md)**: Enable health check on the upstream node, and will automatically filter unhealthy nodes during load balancing to ensure system stability. [#249](https://github.com/apache/incubator-apisix/pull/249)
 - Anti-ReDoS(Regular expression Denial of Service). [#252](https://github.com/apache/incubator-apisix/pull/250)
 - supported debug mode. [#319](https://github.com/apache/incubator-apisix/pull/319)
@@ -212,17 +229,21 @@ This release brings many new features such as health check and circuit breaker, 
 - added desc for upstream and service in schema. [#289](https://github.com/apache/incubator-apisix/pull/289)
 
 ### Plugins
+
 - :sunrise: **[OpenTracing](https://github.com/apache/incubator-apisix/blob/master/doc/plugins/zipkin.md)**: support Zipkin and Apache SkyWalking. [#304](https://github.com/apache/incubator-apisix/pull/304)
 - [JWT auth](https://github.com/apache/incubator-apisix/blob/master/doc/plugins/jwt-auth-cn.md). [#303](https://github.com/apache/incubator-apisix/pull/303)
 
 ### CLI
+
 - support multiple ips of `allow`. [#340](https://github.com/apache/incubator-apisix/pull/340)
 - supported real_ip configure in nginx.conf and added functions to get ip and remote ip. [#236](https://github.com/apache/incubator-apisix/pull/236)
 
 ### Dashboard
+
 - :sunrise: **add built-in dashboard**. [#327](https://github.com/apache/incubator-apisix/pull/327)
 
 ### Test
+
 - support OSX in Travis CI. [#217](https://github.com/apache/incubator-apisix/pull/217)
 - installed all of the dependencies to `deps` folder. [#248](https://github.com/apache/incubator-apisix/pull/248)
 

--- a/doc/benchmark.md
+++ b/doc/benchmark.md
@@ -18,27 +18,33 @@
 -->
 
 [Chinese](benchmark-cn.md)
+
 ### Benchmark Environments
+
 n1-highcpu-8 (8 vCPUs, 7.2 GB memory) on Google Cloud
 
 But we **only** used 4 cores to run APISIX, and left 4 cores for system and [wrk](https://github.com/wg/wrk),
 which is the HTTP benchmarking tool.
 
 ### Benchmark Test for reverse proxy
+
 Only used APISIX as the reverse proxy server, with no logging, limit rate, or other plugins enabled,
 and the response size was 1KB.
 
 #### QPS
+
 The x-axis means the size of CPU core, and the y-axis is QPS.
 
 <img src="../doc/images/benchmark-1.jpg" width="70%" height="70%">
 
 #### Latency
+
 Note the y-axis latency in **microsecond(μs)** not millisecond.
 
 <img src="../doc/images/latency-1.jpg" width="70%" height="70%">
 
 #### Flame Graph
+
 The result of Flame Graph:
 ![](../doc/images/flamegraph-1.jpg)
 
@@ -60,26 +66,30 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f13
 ```
 
 then run wrk:
+
 ```shell
 wrk -d 60 --latency http://127.0.0.1:9080/hello
 ```
 
 ### Benchmark Test for reverse proxy, enabled 2 plugins
+
 Only used APISIX as the reverse proxy server, enabled the limit rate and prometheus plugins,
 and the response size was 1KB.
 
 #### QPS
+
 The x-axis means the size of CPU core, and the y-axis is QPS.
 
 <img src="../doc/images/benchmark-2.jpg" width="70%" height="70%">
 
-
 #### Latency
+
 Note the y-axis latency in **microsecond(μs)** not millisecond.
 
 <img src="../doc/images/latency-2.jpg" width="70%" height="70%">
 
 #### Flame Graph
+
 The result of Flame Graph:
 ![](../doc/images/flamegraph-2.jpg)
 
@@ -110,6 +120,7 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f13
 ```
 
 then run wrk:
+
 ```shell
 wrk -d 60 --latency http://127.0.0.1:9080/hello
 ```

--- a/doc/how-to-build-cn.md
+++ b/doc/how-to-build-cn.md
@@ -16,9 +16,11 @@
 # limitations under the License.
 #
 -->
+
 # 构建 Apache APISIX
 
 ## 1. 安装依赖
+
 Apache APISIX 的运行环境需要 Nginx 和 etcd，
 
 所以在安装前，请根据不同的操作系统来[安装依赖](install-dependencies.md)。
@@ -37,7 +39,8 @@ tar zxvf apache-apisix-1.1-incubating-src.tar.gz
 ```
 
 安装运行时依赖的 Lua 库：
-```
+
+```shell
 cd apache-apisix-1.1-incubating
 make deps
 ```
@@ -111,12 +114,12 @@ Makefile rules:
     * 直接运行：`make test`
     * 指定 nginx 二进制路径：`TEST_NGINX_BINARY=/usr/local/bin/openresty prove -Itest-nginx/lib -r t`
 
-##### 疑难排解
+### 疑难排解
 
 如果遇到问题 `Error unknown directive "lua_package_path" in /API_ASPIX/incubator-apisix/t/servroot/conf/nginx.conf`
 确保将openresty设置为默认的nginx并按如下所示导出路径。
 
- * export PATH=/usr/local/openresty/nginx/sbin:$PATH
+* export PATH=/usr/local/openresty/nginx/sbin:$PATH
 
 ## 5. 更新 Admin API 的 token ，保护 Apache APISIX
 

--- a/doc/how-to-build.md
+++ b/doc/how-to-build.md
@@ -20,6 +20,7 @@
 # Build Apache APISIX
 
 ## 1. Install dependencies
+
 The runtime environment for Apache APISIX requires Nginx and etcd.
 
 So before installation, please follow the different operating systems [install Dependencies](install-dependencies.md).
@@ -38,6 +39,7 @@ tar zxvf apache-apisix-1.1-incubating-src.tar.gz
 ```
 
 Install the Lua libraries that the runtime depends on:
+
 ```shell
 cd apache-apisix-1.1-incubating
 make deps
@@ -113,12 +115,12 @@ Makefile rules:
     * Run the test cases: `make test`
     * To set the path of nginx to run the test cases: `TEST_NGINX_BINARY=/usr/local/bin/openresty prove -Itest-nginx/lib -r t`
 
-##### Troubleshoot
+### Troubleshoot
 
 If you run in to an issue `Error unknown directive "lua_package_path" in /API_ASPIX/incubator-apisix/t/servroot/conf/nginx.conf`
 make sure to set openresty as default nginx. And export the path as below.
 
- * export PATH=/usr/local/openresty/nginx/sbin:$PATH
+* export PATH=/usr/local/openresty/nginx/sbin:$PATH
 
 ## 5. Update Admin API token to protect Apache APISIX
 


### PR DESCRIPTION
fix doc style of how-to-build-cn.md and how-to-build.md
Full changelog
fix doc style of how-to-build-cn.md and how-to-build.md
Issues resolved

related issu: #1273