### PR TITLE
bugfix(CI): avoid to install APISIX to `deps` folder, that is a bug for older luarocks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,24 @@ matrix:
       services:
         - docker
       env: OSNAME=linux_openresty
+    - os: osx
+      env: OSNAME=osx_openresty
+      cache:
+        directories:
+          - $HOME/Library/Caches/Homebrew
+          - /usr/local/Homebrew
+    - os: linux
+      services:
+        - docker
+      env: OSNAME=linux_tengine
+    - os: linux
+      services:
+        - docker
+      env: OSNAME=linux_apisix_master_luarocks
+    - os: linux
+      services:
+        - docker
+      env: OSNAME=linux_apisix_current_luarocks
 
 language: c
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,24 +7,6 @@ matrix:
       services:
         - docker
       env: OSNAME=linux_openresty
-    - os: osx
-      env: OSNAME=osx_openresty
-      cache:
-        directories:
-          - $HOME/Library/Caches/Homebrew
-          - /usr/local/Homebrew
-    - os: linux
-      services:
-        - docker
-      env: OSNAME=linux_tengine
-    - os: linux
-      services:
-        - docker
-      env: OSNAME=linux_apisix_master_luarocks
-    - os: linux
-      services:
-        - docker
-      env: OSNAME=linux_apisix_current_luarocks
 
 language: c
 
@@ -38,8 +20,6 @@ addons:
       - libssl-dev
       - perl
       - etcd
-      - luarocks
-      - lua-check
   homebrew:
     update: true
 

--- a/.travis/linux_apisix_current_luarocks_runner.sh
+++ b/.travis/linux_apisix_current_luarocks_runner.sh
@@ -51,8 +51,8 @@ script() {
     sudo rm -rf /usr/local/apisix
 
     # install APISIX with local version
-    sudo luarocks install rockspec/apisix-master-0.rockspec --only-deps
-    sudo luarocks make rockspec/apisix-master-0.rockspec
+    sudo luarocks install rockspec/apisix-master-0.rockspec --only-deps  > build.log 2>&1 || (cat build.log && exit 1)
+    sudo luarocks make rockspec/apisix-master-0.rockspec > build.log 2>&1 || (cat build.log && exit 1)
 
     # show install file
     luarocks show apisix

--- a/.travis/linux_apisix_current_luarocks_runner.sh
+++ b/.travis/linux_apisix_current_luarocks_runner.sh
@@ -71,9 +71,6 @@ script() {
         cat /usr/local/apisix/logs/error.log
         exit 1
     fi
-
-    sudo luarocks purge --tree=/usr/local
-    sudo rm -rf /usr/local/apisix
 }
 
 case_opt=$1

--- a/.travis/linux_apisix_current_luarocks_runner.sh
+++ b/.travis/linux_apisix_current_luarocks_runner.sh
@@ -30,7 +30,16 @@ do_install() {
     sudo add-apt-repository -y ppa:longsleep/golang-backports
 
     sudo apt-get update
-    sudo apt-get install openresty-debug
+    sudo apt-get install openresty-debug lua5.1 liblua5.1-0-dev
+
+    wget https://github.com/luarocks/luarocks/archive/v2.4.4.tar.gz
+    tar -xf v2.4.4.tar.gz
+    cd luarocks-2.4.4
+    ./configure --prefix=/usr > build.log 2>&1 || (cat build.log && exit 1)
+    make build > build.log 2>&1 || (cat build.log && exit 1)
+    sudo make install > build.log 2>&1 || (cat build.log && exit 1)
+    cd ..
+    rm -rf luarocks-2.4.4
 }
 
 script() {

--- a/.travis/linux_apisix_master_luarocks_runner.sh
+++ b/.travis/linux_apisix_master_luarocks_runner.sh
@@ -81,9 +81,6 @@ script() {
         cat /usr/local/apisix/logs/error.log
         exit 1
     fi
-
-    sudo luarocks remove rockspec/apisix-master-0.rockspec
-    sudo luarocks purge --tree=/usr/local
 }
 
 case_opt=$1

--- a/.travis/linux_apisix_master_luarocks_runner.sh
+++ b/.travis/linux_apisix_master_luarocks_runner.sh
@@ -52,18 +52,17 @@ script() {
 
     # install APISIX by shell
     sudo mkdir -p /usr/local/apisix/deps
-    sudo PATH=$PATH ./utils/install-apisix.sh install
+    sudo PATH=$PATH ./utils/install-apisix.sh install > build.log 2>&1 || (cat build.log && exit 1)
 
     sudo PATH=$PATH apisix help
     sudo PATH=$PATH apisix init
     sudo PATH=$PATH apisix start
     sudo PATH=$PATH apisix stop
 
-    sudo PATH=$PATH ./utils/install-apisix.sh remove
+    sudo PATH=$PATH ./utils/install-apisix.sh remove > build.log 2>&1 || (cat build.log && exit 1)
 
     # install APISIX by luarocks
-    sudo mkdir -p /usr/local/apisix
-    sudo luarocks install rockspec/apisix-master-0.rockspec
+    sudo luarocks install rockspec/apisix-master-0.rockspec > build.log 2>&1 || (cat build.log && exit 1)
 
     # show install files
     luarocks show apisix

--- a/.travis/linux_apisix_master_luarocks_runner.sh
+++ b/.travis/linux_apisix_master_luarocks_runner.sh
@@ -62,6 +62,7 @@ script() {
     sudo PATH=$PATH ./utils/install-apisix.sh remove
 
     # install APISIX by luarocks
+    sudo mkdir -p /usr/local/apisix
     sudo luarocks install rockspec/apisix-master-0.rockspec
 
     # show install files

--- a/.travis/linux_apisix_master_luarocks_runner.sh
+++ b/.travis/linux_apisix_master_luarocks_runner.sh
@@ -30,7 +30,16 @@ do_install() {
     sudo add-apt-repository -y ppa:longsleep/golang-backports
 
     sudo apt-get update
-    sudo apt-get install openresty-debug
+    sudo apt-get install openresty-debug lua5.1 liblua5.1-0-dev
+
+    wget https://github.com/luarocks/luarocks/archive/v2.4.4.tar.gz
+    tar -xf v2.4.4.tar.gz
+    cd luarocks-2.4.4
+    ./configure --prefix=/usr > build.log 2>&1 || (cat build.log && exit 1)
+    make build > build.log 2>&1 || (cat build.log && exit 1)
+    sudo make install > build.log 2>&1 || (cat build.log && exit 1)
+    cd ..
+    rm -rf luarocks-2.4.4
 }
 
 script() {

--- a/.travis/linux_openresty_runner.sh
+++ b/.travis/linux_openresty_runner.sh
@@ -23,8 +23,10 @@ export_or_prefix() {
 }
 
 create_lua_deps() {
-    sudo luarocks make --lua-dir=${OPENRESTY_PREFIX}/luajit rockspec/apisix-master-0.rockspec --tree=deps --only-deps --local
     echo "Create lua deps cache"
+
+    make deps
+
     sudo rm -rf build-cache/deps
     sudo cp -r deps build-cache/
     sudo cp rockspec/apisix-master-0.rockspec build-cache/
@@ -45,6 +47,8 @@ before_install() {
 }
 
 do_install() {
+    export_or_prefix
+
     wget -qO - https://openresty.org/package/pubkey.gpg | sudo apt-key add -
     sudo apt-get -y update --fix-missing
     sudo apt-get -y install software-properties-common
@@ -52,13 +56,21 @@ do_install() {
     sudo add-apt-repository -y ppa:longsleep/golang-backports
 
     sudo apt-get update
+    sudo apt-get install openresty-debug lua5.1 liblua5.1-0-dev
 
-    sudo apt-get install openresty-debug
-    sudo luarocks install --lua-dir=${OPENRESTY_PREFIX}/luajit luacov-coveralls
+    wget https://github.com/luarocks/luarocks/archive/v2.4.4.tar.gz
+    tar -xf v2.4.4.tar.gz
+    cd luarocks-2.4.4
+    ./configure --prefix=/usr > build.log 2>&1 || (cat build.log && exit 1)
+    make build > build.log 2>&1 || (cat build.log && exit 1)
+    sudo make install > build.log 2>&1 || (cat build.log && exit 1)
+    cd ..
+    rm -rf luarocks-2.4.4
+
+    sudo luarocks install luacov-coveralls --tree=deps --local > build.log 2>&1 || (cat build.log && exit 1)
+    sudo luarocks install luacheck > build.log 2>&1 || (cat build.log && exit 1)
 
     export GO111MOUDULE=on
-
-    export_or_prefix
 
     if [ ! -f "build-cache/apisix-master-0.rockspec" ]; then
         create_lua_deps
@@ -73,6 +85,9 @@ do_install() {
             create_lua_deps
         fi
     fi
+
+    # sudo apt-get install tree -y
+    # tree deps
 
     git clone https://github.com/iresty/test-nginx.git test-nginx
     make utils
@@ -116,8 +131,9 @@ script() {
     ./bin/apisix init
     ./bin/apisix init_etcd
     ./bin/apisix start
-    mkdir -p logs
+
     sleep 1
+    cat logs/error.log
 
     sudo sh ./t/grpc-proxy-test.sh
     sleep 1
@@ -126,7 +142,7 @@ script() {
     sleep 1
 
     make lint && make license-check || exit 1
-    APISIX_ENABLE_LUACOV=1 prove -Itest-nginx/lib -r t
+    APISIX_ENABLE_LUACOV=1 prove -Itest-nginx/lib -r t/plugin/proxy-rewrite.t
 }
 
 after_success() {

--- a/.travis/linux_openresty_runner.sh
+++ b/.travis/linux_openresty_runner.sh
@@ -142,7 +142,7 @@ script() {
     sleep 1
 
     make lint && make license-check || exit 1
-    APISIX_ENABLE_LUACOV=1 prove -Itest-nginx/lib -r t/plugin/proxy-rewrite.t
+    APISIX_ENABLE_LUACOV=1 prove -Itest-nginx/lib -r t
 }
 
 after_success() {

--- a/.travis/linux_tengine_runner.sh
+++ b/.travis/linux_tengine_runner.sh
@@ -25,6 +25,7 @@ export_or_prefix() {
 create_lua_deps() {
     echo "Create lua deps cache"
 
+    rm -rf deps
     make deps
 
     sudo rm -rf build-cache/deps
@@ -227,9 +228,6 @@ do_install() {
     cd ..
     rm -rf luarocks-2.4.4
 
-    sudo luarocks install luacov-coveralls --tree=deps --local > build.log 2>&1 || (cat build.log && exit 1)
-    sudo luarocks install luacheck > build.log 2>&1 || (cat build.log && exit 1)
-
     export GO111MOUDULE=on
 
     if [ ! -f "build-cache/apisix-master-0.rockspec" ]; then
@@ -245,6 +243,9 @@ do_install() {
             create_lua_deps
         fi
     fi
+
+    luarocks install luacov-coveralls --tree=deps --local > build.log 2>&1 || (cat build.log && exit 1)
+    sudo luarocks install luacheck > build.log 2>&1 || (cat build.log && exit 1)
 
     git clone https://github.com/iresty/test-nginx.git test-nginx
     make utils

--- a/.travis/linux_tengine_runner.sh
+++ b/.travis/linux_tengine_runner.sh
@@ -214,6 +214,7 @@ do_install() {
     sudo add-apt-repository -y ppa:longsleep/golang-backports
 
     sudo apt-get update
+    sudo apt-get install openresty-debug lua5.1 liblua5.1-0-dev
 
     tengine_install
 

--- a/.travis/linux_tengine_runner.sh
+++ b/.travis/linux_tengine_runner.sh
@@ -214,7 +214,7 @@ do_install() {
     sudo add-apt-repository -y ppa:longsleep/golang-backports
 
     sudo apt-get update
-    sudo apt-get install openresty-debug lua5.1 liblua5.1-0-dev
+    sudo apt-get install lua5.1 liblua5.1-0-dev
 
     tengine_install
 

--- a/.travis/linux_tengine_runner.sh
+++ b/.travis/linux_tengine_runner.sh
@@ -23,8 +23,10 @@ export_or_prefix() {
 }
 
 create_lua_deps() {
-    sudo luarocks make --lua-dir=${OPENRESTY_PREFIX}/luajit rockspec/apisix-master-0.rockspec --tree=deps --only-deps --local
     echo "Create lua deps cache"
+
+    make deps
+
     sudo rm -rf build-cache/deps
     sudo cp -r deps build-cache/
     sudo cp rockspec/apisix-master-0.rockspec build-cache/
@@ -215,7 +217,17 @@ do_install() {
 
     tengine_install
 
-    sudo luarocks install --lua-dir=${OPENRESTY_PREFIX}/luajit luacov-coveralls
+    wget https://github.com/luarocks/luarocks/archive/v2.4.4.tar.gz
+    tar -xf v2.4.4.tar.gz
+    cd luarocks-2.4.4
+    ./configure --prefix=/usr > build.log 2>&1 || (cat build.log && exit 1)
+    make build > build.log 2>&1 || (cat build.log && exit 1)
+    sudo make install > build.log 2>&1 || (cat build.log && exit 1)
+    cd ..
+    rm -rf luarocks-2.4.4
+
+    sudo luarocks install luacov-coveralls --tree=deps --local > build.log 2>&1 || (cat build.log && exit 1)
+    sudo luarocks install luacheck > build.log 2>&1 || (cat build.log && exit 1)
 
     export GO111MOUDULE=on
 

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,7 @@ reload: default
 ### install:          Install the apisix
 .PHONY: install
 install:
+	$(INSTALL) -d /usr/local/apisix/
 	$(INSTALL) -d /usr/local/apisix/logs/
 	$(INSTALL) -d /usr/local/apisix/conf/cert
 	$(INSTALL) conf/mime.types /usr/local/apisix/conf/mime.types

--- a/apisix/plugins/proxy-rewrite.lua
+++ b/apisix/plugins/proxy-rewrite.lua
@@ -97,6 +97,9 @@ function _M.check_schema(conf)
                 if #field == 0 then
                     return false, 'invalid field length in header'
                 end
+
+                core.log.info("header field: ", field)
+
                 if not core.utils.validate_header_field(field) then
                     return false, 'invalid field character in header'
                 end

--- a/rockspec/apisix-master-0.rockspec
+++ b/rockspec/apisix-master-0.rockspec
@@ -14,6 +14,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 --
+
 package = "apisix"
 version = "master-0"
 supported_platforms = {"linux", "macosx"}

--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -108,8 +108,8 @@ _EOC_
 
     my $stream_enable = $block->stream_enable;
     my $stream_config = $block->stream_config // <<_EOC_;
-    lua_package_path "$apisix_home/deps/share/lua/5.1/?.lua;$apisix_home/apisix/?.lua;$apisix_home/t/?.lua;./?.lua;./?/init.lua;;";
-    lua_package_cpath "$apisix_home/deps/lib/lua/5.1/?.so;$apisix_home/deps/lib64/lua/5.1/?.so;./?.so;;";
+    lua_package_path "./?.lua;./?/init.lua;$apisix_home/deps/share/lua/5.1/?.lua;$apisix_home/apisix/?.lua;$apisix_home/t/?.lua;;";
+    lua_package_cpath "./?.so;$apisix_home/deps/lib/lua/5.1/?.so;$apisix_home/deps/lib64/lua/5.1/?.so;;";
 
     lua_socket_log_errors off;
 
@@ -187,8 +187,8 @@ _EOC_
 
     my $http_config = $block->http_config // '';
     $http_config .= <<_EOC_;
-    lua_package_path "$apisix_home/deps/share/lua/5.1/?.lua;$apisix_home/apisix/?.lua;$apisix_home/t/?.lua;./?.lua;./?/init.lua;;";
-    lua_package_cpath "$apisix_home/deps/lib/lua/5.1/?.so;$apisix_home/deps/lib64/lua/5.1/?.so;./?.so;;";
+    lua_package_path "./?.lua;./?/init.lua;$apisix_home/deps/share/lua/5.1/?.lua;$apisix_home/apisix/?.lua;$apisix_home/t/?.lua;;";
+    lua_package_cpath "./?.so;$apisix_home/deps/lib/lua/5.1/?.so;$apisix_home/deps/lib64/lua/5.1/?.so;;";
 
     lua_shared_dict plugin-limit-req     10m;
     lua_shared_dict plugin-limit-count   10m;

--- a/t/plugin/proxy-rewrite.t
+++ b/t/plugin/proxy-rewrite.t
@@ -957,6 +957,8 @@ GET /t
 qr/invalid field character/
 --- no_error_log
 [error]
+--- error_log
+header field: X-Api:Version
 
 
 

--- a/utils/install-apisix.sh
+++ b/utils/install-apisix.sh
@@ -55,8 +55,8 @@ do_install() {
 
 
 do_remove() {
-    sudo rm -f /usr/local/bin/apisix
-    luarocks purge /usr/local/apisix/deps --tree=/usr/local/apisix/deps
+    sudo rm -f /usr/bin/apisix
+    sudo luarocks purge /usr/local/apisix/deps --tree=/usr/local/apisix/deps
 }
 
 


### PR DESCRIPTION
If the Luarocks version is lower than "v2.4.3", it does not support the "--only-deps" parameter. Even if we set the "--only-deps" parameter, no error message will be given during runtime.

We only wanted to install the dependencies in the `deps` directory, but the APISIX was also installed so that the test case might load the wrong version of the source code.