### PR TITLE
bugfix(Travis): install the `luacov` when create `deps` folder

### DIFF
--- a/.travis/linux_openresty_runner.sh
+++ b/.travis/linux_openresty_runner.sh
@@ -26,6 +26,7 @@ create_lua_deps() {
     echo "Create lua deps cache"
 
     make deps
+    luarocks install luacov-coveralls --tree=deps --local > build.log 2>&1 || (cat build.log && exit 1)
 
     sudo rm -rf build-cache/deps
     sudo cp -r deps build-cache/
@@ -67,7 +68,6 @@ do_install() {
     cd ..
     rm -rf luarocks-2.4.4
 
-    sudo luarocks install luacov-coveralls --tree=deps --local > build.log 2>&1 || (cat build.log && exit 1)
     sudo luarocks install luacheck > build.log 2>&1 || (cat build.log && exit 1)
 
     export GO111MOUDULE=on

--- a/.travis/linux_tengine_runner.sh
+++ b/.travis/linux_tengine_runner.sh
@@ -27,6 +27,7 @@ create_lua_deps() {
 
     rm -rf deps
     make deps
+    luarocks install luacov-coveralls --tree=deps --local > build.log 2>&1 || (cat build.log && exit 1)
 
     sudo rm -rf build-cache/deps
     sudo cp -r deps build-cache/
@@ -244,7 +245,6 @@ do_install() {
         fi
     fi
 
-    luarocks install luacov-coveralls --tree=deps --local > build.log 2>&1 || (cat build.log && exit 1)
     sudo luarocks install luacheck > build.log 2>&1 || (cat build.log && exit 1)
 
     git clone https://github.com/iresty/test-nginx.git test-nginx


### PR DESCRIPTION
fix travis: https://travis-ci.org/github/apache/incubator-apisix/jobs/677082965#L524

Install the `luacov` when create `deps` folder.

Then we can avoid installing "luacov" after copying "deps" from the "build-cache" folder to the current folder.