### PR TITLE
bugfix(lrucache): when creating cached objects, use resty-lock to avoid repeated creation.

### DIFF
--- a/apisix/core/lrucache.lua
+++ b/apisix/core/lrucache.lua
@@ -14,6 +14,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 --
+
 local lru_new = require("resty.lrucache").new
 local resty_lock = require("resty.lock")
 local setmetatable = setmetatable
@@ -21,6 +22,7 @@ local getmetatable = getmetatable
 local type = type
 local tostring = tostring
 local get_phase = ngx.get_phase
+local lock_shdict_name = "lrucache-lock-" .. ngx.config.subsystem
 
 local can_yield_phases = {
     ssl_session_fetch = true,
@@ -108,7 +110,7 @@ local function new_lru_fun(opts)
             return cache_obj
         end
 
-        local lock, err = resty_lock:new("lrucache-lock")
+        local lock, err = resty_lock:new(lock_shdict_name)
         if not lock then
             return nil, "failed to create lock: " .. err
         end

--- a/apisix/core/lrucache.lua
+++ b/apisix/core/lrucache.lua
@@ -15,9 +15,21 @@
 -- limitations under the License.
 --
 local lru_new = require("resty.lrucache").new
+local resty_lock = require("resty.lock")
 local setmetatable = setmetatable
 local getmetatable = getmetatable
 local type = type
+local tostring = tostring
+local get_phase = ngx.get_phase
+
+local can_yield_phases = {
+    ssl_session_fetch = true,
+    ssl_session_store = true,
+    rewrite = true,
+    access = true,
+    content = true,
+    timer = true
+}
 
 -- todo: support to config it in YAML.
 local GLOBAL_ITEMS_COUNT= 1024
@@ -28,6 +40,38 @@ local global_lru_fun
 local lua_metatab = {}
 
 
+local function fetch_valid_cache(lru_obj, invalid_stale, item_ttl,
+                                 item_release, key, version)
+    local obj, stale_obj = lru_obj:get(key)
+    if obj and obj._cache_ver == version then
+        local met_tab = getmetatable(obj)
+        if met_tab ~= lua_metatab then
+            return obj
+        end
+
+        return obj.val
+    end
+
+    if not invalid_stale and stale_obj and
+        stale_obj._cache_ver == version then
+        lru_obj:set(key, stale_obj, item_ttl)
+
+        local met_tab = getmetatable(stale_obj)
+        if met_tab ~= lua_metatab then
+            return stale_obj
+        end
+
+        return stale_obj.val
+    end
+
+    if item_release and obj then
+        item_release(obj)
+    end
+
+    return nil
+end
+
+
 local function new_lru_fun(opts)
     local item_count = opts and opts.count or GLOBAL_ITEMS_COUNT
     local item_ttl = opts and opts.ttl or GLOBAL_TTL
@@ -36,34 +80,53 @@ local function new_lru_fun(opts)
     local lru_obj = lru_new(item_count)
 
     return function (key, version, create_obj_fun, ...)
-        local obj, stale_obj = lru_obj:get(key)
-        if obj and obj._cache_ver == version then
-            local met_tab = getmetatable(obj)
-            if met_tab ~= lua_metatab then
-                return obj
+        if not can_yield_phases[get_phase()] then
+            local cache_obj = fetch_valid_cache(lru_obj, invalid_stale,
+                                item_ttl, item_release, key, version)
+            if cache_obj then
+                return cache_obj
             end
 
-            return obj.val
-        end
+            local obj, err = create_obj_fun(...)
+            if type(obj) == 'table' then
+                obj._cache_ver = version
+                lru_obj:set(key, obj, item_ttl)
 
-        if not invalid_stale and stale_obj and
-           stale_obj._cache_ver == version then
-            lru_obj:set(key, stale_obj, item_ttl)
-
-            local met_tab = getmetatable(stale_obj)
-            if met_tab ~= lua_metatab then
-                return stale_obj
+            elseif obj ~= nil then
+                local cached_obj = setmetatable(
+                        {val = obj, _cache_ver = version},
+                        lua_metatab)
+                lru_obj:set(key, cached_obj, item_ttl)
             end
 
-            return stale_obj.val
+            return obj, err
         end
 
-        if item_release and obj then
-            item_release(obj)
+        local cache_obj = fetch_valid_cache(lru_obj, invalid_stale, item_ttl,
+                            item_release, key, version)
+        if cache_obj then
+            return cache_obj
         end
 
-        local err
-        obj, err = create_obj_fun(...)
+        local lock, err = resty_lock:new("lrucache-lock")
+        if not lock then
+            return nil, "failed to create lock: " .. err
+        end
+
+        local key_s = tostring(key)
+        local elapsed, err = lock:lock(key_s)
+        if not elapsed then
+            return nil, "failed to acquire the lock: " .. err
+        end
+
+        cache_obj = fetch_valid_cache(lru_obj, invalid_stale, item_ttl,
+                        nil, key, version)
+        if cache_obj then
+            lock:unlock()
+            return cache_obj
+        end
+
+        local obj, err = create_obj_fun(...)
         if type(obj) == 'table' then
             obj._cache_ver = version
             lru_obj:set(key, obj, item_ttl)
@@ -73,6 +136,7 @@ local function new_lru_fun(opts)
                                             lua_metatab)
             lru_obj:set(key, cached_obj, item_ttl)
         end
+        lock:unlock()
 
         return obj, err
     end

--- a/apisix/core/lrucache.lua
+++ b/apisix/core/lrucache.lua
@@ -22,7 +22,10 @@ local getmetatable = getmetatable
 local type = type
 local tostring = tostring
 local get_phase = ngx.get_phase
-local lock_shdict_name = "lrucache-lock-" .. ngx.config.subsystem
+local lock_shdict_name = "lrucache-lock"
+if ngx.config.subsystem == "stream" then
+    lock_shdict_name = lock_shdict_name .. "-" .. ngx.config.subsystem
+end
 
 local can_yield_phases = {
     ssl_session_fetch = true,

--- a/apisix/core/schema.lua
+++ b/apisix/core/schema.lua
@@ -14,6 +14,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 --
+
 local jsonschema = require('jsonschema')
 local lrucache = require("apisix.core.lrucache")
 local cached_validator = lrucache.new({count = 1000, ttl = 0})
@@ -31,7 +32,12 @@ end
 
 
 function _M.check(schema, json)
-    local validator = cached_validator(schema, nil, create_validator, schema)
+    local validator, err = cached_validator(schema, nil,
+                                create_validator, schema)
+    if not validator then
+        return nil, err
+    end
+
     return validator(json)
 end
 

--- a/bin/apisix
+++ b/bin/apisix
@@ -176,6 +176,7 @@ http {
     lua_shared_dict plugin-limit-conn    10m;
     lua_shared_dict upstream-healthcheck 10m;
     lua_shared_dict worker-events        10m;
+    lua_shared_dict lrucache-lock        10m;
 
     # for openid-connect plugin
     lua_shared_dict discovery             1m; # cache for discovery metadata documents

--- a/bin/apisix
+++ b/bin/apisix
@@ -118,6 +118,8 @@ stream {
                       .. [=[{*lua_cpath*};";
     lua_socket_log_errors off;
 
+    lua_shared_dict lrucache-lock        10m;
+
     resolver {% for _, dns_addr in ipairs(dns_resolver or {}) do %} {*dns_addr*} {% end %} valid={*dns_resolver_valid*};
     resolver_timeout {*resolver_timeout*};
 

--- a/bin/apisix
+++ b/bin/apisix
@@ -118,8 +118,6 @@ stream {
                       .. [=[{*lua_cpath*};";
     lua_socket_log_errors off;
 
-    lua_shared_dict lrucache-lock        10m;
-
     resolver {% for _, dns_addr in ipairs(dns_resolver or {}) do %} {*dns_addr*} {% end %} valid={*dns_resolver_valid*};
     resolver_timeout {*resolver_timeout*};
 

--- a/bin/apisix
+++ b/bin/apisix
@@ -118,6 +118,8 @@ stream {
                       .. [=[{*lua_cpath*};";
     lua_socket_log_errors off;
 
+    lua_shared_dict lrucache-lock-stream   10m;
+
     resolver {% for _, dns_addr in ipairs(dns_resolver or {}) do %} {*dns_addr*} {% end %} valid={*dns_resolver_valid*};
     resolver_timeout {*resolver_timeout*};
 

--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -198,7 +198,7 @@ _EOC_
     lua_shared_dict prometheus-metrics   10m;
     lua_shared_dict upstream-healthcheck 32m;
     lua_shared_dict worker-events        10m;
-    lua_shared_dict lrucache-lock-http   10m;
+    lua_shared_dict lrucache-lock        10m;
 
     resolver $dns_addrs_str;
     resolver_timeout 5;

--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -113,6 +113,8 @@ _EOC_
 
     lua_socket_log_errors off;
 
+    lua_shared_dict lrucache-lock        10m;
+
     upstream apisix_backend {
         server 127.0.0.1:1900;
         balancer_by_lua_block {

--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -113,7 +113,7 @@ _EOC_
 
     lua_socket_log_errors off;
 
-    lua_shared_dict lrucache-lock        10m;
+    lua_shared_dict lrucache-lock-stream   10m;
 
     upstream apisix_backend {
         server 127.0.0.1:1900;
@@ -198,7 +198,7 @@ _EOC_
     lua_shared_dict prometheus-metrics   10m;
     lua_shared_dict upstream-healthcheck 32m;
     lua_shared_dict worker-events        10m;
-    lua_shared_dict lrucache-lock        10m;
+    lua_shared_dict lrucache-lock-http   10m;
 
     resolver $dns_addrs_str;
     resolver_timeout 5;

--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -196,6 +196,7 @@ _EOC_
     lua_shared_dict prometheus-metrics   10m;
     lua_shared_dict upstream-healthcheck 32m;
     lua_shared_dict worker-events        10m;
+    lua_shared_dict lrucache-lock        10m;
 
     resolver $dns_addrs_str;
     resolver_timeout 5;

--- a/t/core/lrucache.t
+++ b/t/core/lrucache.t
@@ -241,3 +241,41 @@ obj: {"idx":1,"_cache_ver":"ver"}
 obj: {"idx":2,"_cache_ver":"ver"}
 --- no_error_log
 [error]
+
+
+
+=== TEST 7: when creating cached objects, use resty-lock to avoid repeated creation.
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+
+            local idx = 0
+            local function create_obj()
+                idx = idx + 1
+                ngx.sleep(0.1)
+                return {idx = idx}
+            end
+
+            local lru_get = core.lrucache.new({
+                ttl = 0.1, count = 256, invalid_stale = true,
+            })
+
+            local function f()
+                local obj = lru_get("key", "ver", create_obj)
+                ngx.say("obj: ", core.json.encode(obj))
+            end
+
+            ngx.thread.spawn(f)
+            ngx.thread.spawn(f)
+
+            ngx.sleep(0.3)
+        }
+    }
+--- request
+GET /t
+--- response_body
+obj: {"idx":1,"_cache_ver":"ver"}
+obj: {"idx":1,"_cache_ver":"ver"}
+--- no_error_log
+[error]

--- a/t/core/schema.t
+++ b/t/core/schema.t
@@ -131,3 +131,25 @@ GET /t
 passed
 --- no_error_log
 [error]
+
+
+
+=== TEST 4: invalid schema
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local schema = {
+                type = "invalid type"
+            }
+
+            local ok, err = core.schema.check(schema, 11)
+            ngx.say("ok: ", ok, " err: ", err)
+        }
+    }
+--- request
+GET /t
+--- response_body eval
+qr/ok: false err: .* invalid JSON type: invalid type/
+--- no_error_log
+[error]


### PR DESCRIPTION
one common use case for this library is avoid the so-called "dog-pile effect",     
that is, to limit concurrent backend queries for the same key when a cache miss happens.