### PR TITLE
Adding util function to remove stale objects from the log buffer

### DIFF
--- a/apisix/utils/log-util.lua
+++ b/apisix/utils/log-util.lua
@@ -18,6 +18,21 @@ local core     = require("apisix.core")
 
 local _M = {}
 
+
+local function remove_stale_objects(premature, log_buffer)
+    if premature then
+        return
+    end
+
+    for key, batch in ipairs(log_buffer) do
+        if #batch.entry_buffer.entries == 0 and #batch.batch_to_process == 0 then
+            core.log.debug("removing batch processor stale object, route id:" .. tostring(key))
+            log_buffer[key] = nil
+        end
+    end
+end
+
+
 local function get_full_log(ngx)
     local ctx = ngx.ctx.api_ctx
     local var = ctx.var

--- a/apisix/utils/log-util.lua
+++ b/apisix/utils/log-util.lua
@@ -19,7 +19,7 @@ local core     = require("apisix.core")
 local _M = {}
 
 
-local function remove_stale_objects(premature, log_buffer)
+local function remove_stale_objects(premature, log_buffer, status)
     if premature then
         return
     end
@@ -30,6 +30,7 @@ local function remove_stale_objects(premature, log_buffer)
             log_buffer[key] = nil
         end
     end
+    status = false
 end
 
 


### PR DESCRIPTION
Fix #1494 

This function should be called via loggers which uses the batch processor:

```lua
local buffers = {}
local stale_timer_running = false;
function _M.log(conf)
    local entry = log_util.get_full_log(ngx)

     if not stale_timer_running then
      -- run the timer every 30 mins if any log is present
      timer_at(30000, remove_stale_objects, buffers, stale_timer_running)
      stale_timer_running = true
    end
}
```