### PR TITLE
Generalize logger sending methods.

### DIFF
--- a/apisix/plugins/kafka-logger.lua
+++ b/apisix/plugins/kafka-logger.lua
@@ -58,6 +58,8 @@ end
 
 
 local function send_kafka_data(conf, log_message)
+    local err_msg
+    local res = true
     if core.table.nkeys(conf.broker_list) == 0 then
         core.log.error("failed to identify the broker specified")
     end
@@ -80,13 +82,17 @@ local function send_kafka_data(conf, log_message)
 
     local prod, err = producer:new(broker_list,broker_config)
     if err then
-        return nil, "failed to identify the broker specified: " .. err
+        res = false
+        err_msg = "failed to identify the broker specified: " .. err
     end
 
     local ok, err = prod:send(conf.kafka_topic, conf.key, log_message)
     if not ok then
-        return nil, "failed to send data to Kafka topic" .. err
+        res = false
+        err_msg = "failed to send data to Kafka topic" .. err
     end
+
+    return res, err_msg
 end
 
 

--- a/apisix/plugins/tcp-logger.lua
+++ b/apisix/plugins/tcp-logger.lua
@@ -89,8 +89,8 @@ local function send_tcp_data(conf, log_message)
 
     ok, err = sock:close()
     if not ok then
-        core.log.error("failed to close the TCP connection, host[",
-                        conf.host, "] port[", conf.port, "] ", err)
+        err_msg = "failed to close the TCP server: host[" .. conf.host
+                .. "] port[" .. tostring(conf.port) .. "] err: " .. err
     end
 
     return res, err_msg

--- a/apisix/plugins/tcp-logger.lua
+++ b/apisix/plugins/tcp-logger.lua
@@ -66,14 +66,16 @@ local function send_tcp_data(conf, log_message)
 
     local ok, err = sock:connect(conf.host, conf.port)
     if not ok then
-        return false, "failed to connect to TCP server: host[" .. conf.host
+        res = false
+        err_msg = "failed to connect to TCP server: host[" .. conf.host
                       .. "] port[" .. tostring(conf.port) .. "] err: " .. err
     end
 
     if conf.tls then
         ok, err = sock:sslhandshake(true, conf.tls_options, false)
         if not ok then
-            return false, "failed to to perform TLS handshake to TCP server: host["
+            res = false
+            err_msg = "failed to to perform TLS handshake to TCP server: host["
                           .. conf.host .. "] port[" .. tostring(conf.port) .. "] err: " .. err
         end
     end

--- a/apisix/plugins/udp-logger.lua
+++ b/apisix/plugins/udp-logger.lua
@@ -57,7 +57,8 @@ local function send_udp_data(conf, log_message)
     local ok, err = sock:setpeername(conf.host, conf.port)
 
     if not ok then
-        return nil, "failed to connect to UDP server: host[" .. conf.host
+        res = false
+        err_msg = "failed to connect to UDP server: host[" .. conf.host
                     .. "] port[" .. tostring(conf.port) .. "] err: " .. err
     end
 
@@ -70,8 +71,9 @@ local function send_udp_data(conf, log_message)
 
     ok, err = sock:close()
     if not ok then
-        core.log.error("failed to close the UDP connection, host[",
-                        conf.host, "] port[", conf.port, "] ", err)
+        res = false
+        err_msg = "failed to close the UDP connection, host[",
+                        conf.host, "] port[", conf.port, "] " .. err
     end
 
     return res, err_msg

--- a/apisix/plugins/udp-logger.lua
+++ b/apisix/plugins/udp-logger.lua
@@ -72,8 +72,8 @@ local function send_udp_data(conf, log_message)
     ok, err = sock:close()
     if not ok then
         res = false
-        err_msg = "failed to close the UDP connection, host[",
-                        conf.host, "] port[", conf.port, "] " .. err
+        err_msg = "failed to close the UDP connection: host[" .. conf.host
+                .. "] port[" .. tostring(conf.port) .. "] err:" .. err
     end
 
     return res, err_msg


### PR DESCRIPTION
It's good to generalize all loggers sending methods to return the same params in a same way.
