### PR TITLE
[core]control the output format of access.log through the http.access_log_format field in config.yaml

### DIFF
--- a/.travis/apisix_cli_test.sh
+++ b/.travis/apisix_cli_test.sh
@@ -72,3 +72,19 @@ done
 
 sed -i '/dns_resolver:/,+4s/^#//'  conf/config.yaml
 echo "passed: system nameserver imported"
+
+# check access log format
+
+sed -i 's/#access_log_format: |+/access_log_format: "test config accesslog"/g' conf/config.yaml
+
+make init
+
+grep "log_format main test config accesslog" conf/nginx.conf > /dev/null
+if [ ! $? -eq 0 ]; then
+    echo "failed: failed to config the log_format"
+    exit 1
+fi
+
+echo "passed: change access.log format"
+sed -i 's/access_log_format: "test config accesslog"/\#access_log_format: |+/g' conf/config.yaml
+

--- a/bin/apisix
+++ b/bin/apisix
@@ -225,7 +225,11 @@ http {
     lua_regex_match_limit 100000;
     lua_regex_cache_max_entries 8192;
 
+    {% if http.access_log_format then %}
+    log_format main {* http.access_log_format *};
+    {% else %}
     log_format main '$remote_addr - $remote_user [$time_local] $http_host "$request" $status $body_bytes_sent $request_time "$http_referer" "$http_user_agent" $upstream_addr $upstream_status $upstream_response_time';
+    {% end %}
 
     access_log {* http.access_log *} main buffer=32768 flush=3;
     open_file_cache  max=1000 inactive=60;

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -101,9 +101,10 @@ nginx_config:                     # config for render the template to genarate n
   http:
     access_log: "logs/access.log"
     #access_log_format: |+         # access.log recommended format
-    #  '[host:$http_host][uri:$uri][scheme:$scheme][rsp_st:$status][ups_st:$upstream_status][cip:$remote_addr][uip:$upstream_addr][vip:$server_addr]'
-    #  '[rsp_len:$bytes_sent][req_len:$request_length][req_t:$request_time][ups_rsp_t:$upstream_response_time][ups_conn_t:$upstream_connect_time]'
-    #  '[ups_head_t:$upstream_header_time][tcp_rtt:$tcpinfo_rtt][$pid][$time_local][req_id:$request_id]'
+    #  '{"host":"$http_host", "uri":"$uri", "scheme":"$scheme", "rsp_st":"$status", "ups_st":"$upstream_status", "cip":"$remote_addr", '
+    #  '"uip":"$upstream_addr", "vip":"$server_addr", "rsp_len":"$bytes_sent", "req_len":"$request_length", "req_t":"$request_time", '
+    #  '"ups_rsp_t":"$upstream_response_time", "ups_conn_t":"$upstream_connect_time", "ups_head_t":"$upstream_header_time", "tcp_rtt":"$tcpinfo_rtt", '
+    #  '"pid":"$pid", "time_local":"$time_local", "req_id":"$request_id"}'
 
     keepalive_timeout: 60s         # timeout during which a keep-alive client connection will stay open on the server side.
     client_header_timeout: 60s     # timeout for reading client request header, then 408 (Request Time-out) error is returned to the client

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -100,6 +100,11 @@ nginx_config:                     # config for render the template to genarate n
     worker_connections: 10620
   http:
     access_log: "logs/access.log"
+    #access_log_format: |+         # access.log recommended format
+    #  '[host:$http_host][uri:$uri][scheme:$scheme][rsp_st:$status][ups_st:$upstream_status][cip:$remote_addr][uip:$upstream_addr][vip:$server_addr]'
+    #  '[rsp_len:$bytes_sent][req_len:$request_length][req_t:$request_time][ups_rsp_t:$upstream_response_time][ups_conn_t:$upstream_connect_time]'
+    #  '[ups_head_t:$upstream_header_time][tcp_rtt:$tcpinfo_rtt][$pid][$time_local][req_id:$request_id]'
+
     keepalive_timeout: 60s         # timeout during which a keep-alive client connection will stay open on the server side.
     client_header_timeout: 60s     # timeout for reading client request header, then 408 (Request Time-out) error is returned to the client
     client_body_timeout: 60s       # timeout for reading client request body, then 408 (Request Time-out) error is returned to the client


### PR DESCRIPTION
You can control the output format of access.log through the http.access_log_format field in config.yaml, and add a recommended access.log format in the comments.

NOTE: Please read the Contributing.md guidelines before submitting your patch:

https://github.com/apache/incubator-apisix/blob/master/Contributing.md#how-to-add-a-new-feature-or-change-an-existing-one

### Summary

SUMMARY_HERE

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issues resolved

Fix #XXX
