### PR TITLE
[log] Optimize the buffer size and flush time

### DIFF
--- a/bin/apisix
+++ b/bin/apisix
@@ -227,7 +227,7 @@ http {
 
     log_format main '$remote_addr - $remote_user [$time_local] $http_host "$request" $status $body_bytes_sent $request_time "$http_referer" "$http_user_agent" $upstream_addr $upstream_status $upstream_response_time';
 
-    access_log {* http.access_log *} main buffer=32768 flush=3;
+    access_log {* http.access_log *} main buffer=4096 flush=1;
     open_file_cache  max=1000 inactive=60;
     client_max_body_size 0;
     keepalive_timeout {* http.keepalive_timeout *};

--- a/bin/apisix
+++ b/bin/apisix
@@ -227,7 +227,7 @@ http {
 
     log_format main '$remote_addr - $remote_user [$time_local] $http_host "$request" $status $body_bytes_sent $request_time "$http_referer" "$http_user_agent" $upstream_addr $upstream_status $upstream_response_time';
 
-    access_log {* http.access_log *} main buffer=4096 flush=1;
+    access_log {* http.access_log *} main buffer=16384 flush=1;
     open_file_cache  max=1000 inactive=60;
     client_max_body_size 0;
     keepalive_timeout {* http.keepalive_timeout *};


### PR DESCRIPTION
1. buffer=4096 is better for Writes of more than PIPE_BUF bytes may be nonatomic
2. flush=1. Since the log buffer is lowered, the flush time should also be lowered.

NOTE: Please read the Contributing.md guidelines before submitting your patch:

https://github.com/apache/incubator-apisix/blob/master/Contributing.md#how-to-add-a-new-feature-or-change-an-existing-one

Fix https://github.com/apache/incubator-apisix/issues/1567
