### PR TITLE
doc: add asf.yaml.

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+github:
+    description: The Cloud-Native API Gateway
+    homepage: https://apisix.apache.org/
+    labels:
+      - api-gateway
+      - cloud-native
+      - nginx
+      - lua
+      - luajit
+      - apigateway
+      - microservices
+      - api
+      - loadbalancing
+      - reverse-proxy
+      - api-management
+      - apisix
+      - serverless
+      - iot
+      - devops
+      - kubernetes
+      - docker
+
+    enabled_merge_buttons:
+      squash:  true
+      merge:   false
+      rebase:  false


### PR DESCRIPTION
`asf.yaml` is used to control the description and tags of the project