### PR TITLE
bugfix: change the version of skywalking to 1.0-0 

### DIFF
--- a/rockspec/apisix-master-0.rockspec
+++ b/rockspec/apisix-master-0.rockspec
@@ -51,7 +51,7 @@ dependencies = {
     "lua-resty-ipmatcher = 0.6",
     "lua-resty-kafka = 0.07",
     "lua-resty-logger-socket = 2.0-0",
-    "skywalking-nginx-lua-plugin = 1.0",
+    "skywalking-nginx-lua-plugin = 1.0-0",
 }
 
 build = {


### PR DESCRIPTION
 The results are as follows when make deps,
-----
[root@localhost apisix]# make deps
luarocks install --lua-dir=/usr/servers/luajit rockspec/apisix-master-0.rockspec --tree=deps --only-deps --local
Missing dependencies for apisix master-0:
   skywalking-nginx-lua-plugin 1.0-0 (not installed)

apisix master-0 depends on skywalking-nginx-lua-plugin 1.0-0 (not installed)
Installing https://luarocks.org/skywalking-nginx-lua-plugin-1.0.rockspec

Error: Failed installing dependency: https://luarocks.org/skywalking-nginx-lua-plugin-1.0.rockspec - /tmp/luarocks_luarocks-rockspec-skywalking-nginx-lua-plugin-1.0-Eo8MgK/skywalking-nginx-lua-plugin-1.0.rockspec: Type mismatch on field version: invalid value '1.0' does not match '[%w.]+-[%d]+' (using rockspec format 1.0)
-------
By changing  the version of skywalking to 1.0-0, it passed.

