### PR TITLE
[add test case]add testcase for #1625 to test the filed of overhead

### DIFF
--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -110,7 +110,7 @@ function _M.log(conf, ctx)
 
     local overhead = latency
     if ctx.var.upstream_response_time then
-        overhead = overhead - tonumber(ctx.var.upstream_response_time) * 1000
+        overhead =  overhead - tonumber(ctx.var.upstream_response_time) * 1000
     end
     metrics.overhead:observe(overhead,
         gen_arr("request", service_id, balancer_ip))

--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -110,7 +110,7 @@ function _M.log(conf, ctx)
 
     local overhead = latency
     if ctx.var.upstream_response_time then
-        overhead = overhead - tonumber(ctx.var.upstream_response_time)
+        overhead = overhead - tonumber(ctx.var.upstream_response_time) * 1000
     end
     metrics.overhead:observe(overhead,
         gen_arr("request", service_id, balancer_ip))

--- a/t/lib/server.lua
+++ b/t/lib/server.lua
@@ -28,6 +28,11 @@ function _M.hello1()
     ngx.say("hello1 world")
 end
 
+-- mock server for test the fix of overhead's value
+function _M.hello4()
+    ngx.sleep(1)
+    ngx.say("hello4 world")
+end
 
 function _M.server_port()
     ngx.print(ngx.var.server_port)

--- a/t/lib/server.lua
+++ b/t/lib/server.lua
@@ -30,7 +30,7 @@ end
 
 -- mock server for test the fix of overhead's value
 function _M.hello4()
-    ngx.sleep(1)
+    _M.sleep1()
     ngx.say("hello4 world")
 end
 

--- a/t/lib/server.lua
+++ b/t/lib/server.lua
@@ -28,12 +28,6 @@ function _M.hello1()
     ngx.say("hello1 world")
 end
 
--- mock server for test the fix of overhead's value
-function _M.hello4()
-    _M.sleep1()
-    ngx.say("hello4 world")
-end
-
 function _M.server_port()
     ngx.print(ngx.var.server_port)
 end

--- a/t/plugin/prometheus.t
+++ b/t/plugin/prometheus.t
@@ -200,7 +200,7 @@ GET /t
 {"error_msg":"failed to check the configuration of plugin prometheus err: additional properties forbidden, found invalid_property"}
 --- no_error_log
 [error]
----
+
 
 
 === TEST 10: set it in service (with wrong property)
@@ -535,6 +535,8 @@ qr/.*apisix_http_overhead_bucket.*/
 --- no_error_log
 [error]
 
+
+
 === TEST 26: add service 3 to distinguish other services
 --- config
     location /t {
@@ -568,6 +570,8 @@ passed
 --- no_error_log
 [error]
 
+
+
 === TEST 27: add a route 4 to redirect /hello4
 --- config
     location /t {
@@ -594,6 +598,8 @@ passed
 --- no_error_log
 [error]
 
+
+
 === TEST 28: request from client to /hello4 ( all hit, the hello4 sleep 1s)
 --- pipelined_requests eval
 ["GET /hello4", "GET /hello4", "GET /hello4"]
@@ -601,6 +607,7 @@ passed
 [200, 200, 200]
 --- no_error_log
 [error]
+
 
 
 === TEST 29: fetch the prometheus metric data with `overhead`(the overhead < 1s)

--- a/t/plugin/prometheus.t
+++ b/t/plugin/prometheus.t
@@ -617,3 +617,49 @@ GET /apisix/prometheus/metrics
 qr/apisix_http_overhead_bucket.*service=\"3\".*le=\"00500.0.*/
 --- no_error_log
 [error]
+
+
+
+=== TEST 30: delete route 4
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/4',
+                ngx.HTTP_DELETE
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 31: delete service 3
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/services/3',
+                ngx.HTTP_DELETE
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]

--- a/t/plugin/prometheus.t
+++ b/t/plugin/prometheus.t
@@ -572,7 +572,7 @@ passed
 
 
 
-=== TEST 27: add a route 4 to redirect /hello4
+=== TEST 27: add a route 4 to redirect /sleep1
 --- config
     location /t {
         content_by_lua_block {
@@ -581,7 +581,7 @@ passed
                  ngx.HTTP_PUT,
                  [[{
                     "service_id": 3,
-                    "uri": "/hello4"
+                    "uri": "/sleep1"
                 }]]
                 )
 
@@ -600,9 +600,9 @@ passed
 
 
 
-=== TEST 28: request from client to /hello4 ( all hit, the hello4 sleep 1s)
+=== TEST 28: request from client to /sleep1 ( all hit)
 --- pipelined_requests eval
-["GET /hello4", "GET /hello4", "GET /hello4"]
+["GET /sleep1", "GET /sleep1", "GET /sleep1"]
 --- error_code eval
 [200, 200, 200]
 --- no_error_log


### PR DESCRIPTION
### Summary
correct the value of overhead in  plugins/prometheus/exporter.lua
* [Add related tests]
prometheus.t  test 26 to 29
1st  add a mock service /hello4 to sleep 1s， 

=== TEST 26: add a service 3 to distinguish other services
=== TEST 27: add a route 4 to redirect /hello4
=== TEST 28: request from client to /hello4 ( all hit, the hello4 sleep 1s)
=== TEST 29: fetch the prometheus metric data with `overhead`(the overhead < 1s)
With the previous error, the value of overhead was above 1s,  the overhead's value corrected  is less than 1s by fix the error.

### Issues resolved

Fix #1625
