### PR TITLE
compatibility of benchmark script and apisix reload command on OSX

### DIFF
--- a/benchmark/run.sh
+++ b/benchmark/run.sh
@@ -36,7 +36,12 @@ function onCtrlC () {
     sudo openresty -p $PWD/benchmark/server -s stop || exit 1
 }
 
-sed  -i "s/worker_processes .*/worker_processes $worker_cnt/g" conf/nginx.conf
+if [[ "$(uname)" == "Darwin" ]]; then
+    sed  -i "" "s/worker_processes .*/worker_processes $worker_cnt;/g" conf/nginx.conf
+else
+    sed  -i "s/worker_processes .*/worker_processes $worker_cnt;/g" conf/nginx.conf
+fi
+
 make run
 
 sleep 3

--- a/benchmark/run.sh
+++ b/benchmark/run.sh
@@ -36,7 +36,7 @@ function onCtrlC () {
     sudo openresty -p $PWD/benchmark/server -s stop || exit 1
 }
 
-sed  -i "s/worker_processes [0-9]*/worker_processes $worker_cnt/g" conf/nginx.conf
+sed  -i "s/worker_processes .*/worker_processes $worker_cnt/g" conf/nginx.conf
 make run
 
 sleep 3

--- a/bin/apisix
+++ b/bin/apisix
@@ -838,13 +838,17 @@ end
 
 function _M.reload()
     local test_cmd = openresty_args .. [[ -t -q ]]
-    if os.execute((test_cmd)) ~= 0 then
+    -- When success,
+    -- On linux, os.execute returns 0,
+    -- On macos, os.execute returns 3 values: true, exit, 0, and we need the first.
+    local test_ret = os.execute((test_cmd))
+    if (test_ret == 0 or test_ret == true) then
+        local cmd = openresty_args .. [[ -s reload]]
+        -- print(cmd)
+        os.execute(cmd)
         return
     end
-
-    local cmd = openresty_args .. [[ -s reload]]
-    -- print(cmd)
-    os.execute(cmd)
+    print("test openresty failed")
 end
 
 function _M.version()


### PR DESCRIPTION
### Summary

fix osx compatibility when run `benchmark/run.sh` and `apisix reload`

### Full changelog

* change benchmark script sed from set workers `worker_processes \d+` to `worker_processes .* ` to fit `worker_processes auto`
* change sed command to fit OSX in `benchmark/run.sh`
* fix `apisix reload` on OSX.


### Issues resolved

Fix #1649 