### PR TITLE
[bugfix(CLI)]: check whether  the user has enabled etcd v2 protocol.

### DIFF
--- a/.travis/apisix_cli_test.sh
+++ b/.travis/apisix_cli_test.sh
@@ -23,6 +23,16 @@
 
 set -ex
 
+# check if the user has enabled etcd v2 protocol.
+
+code=$(curl -i -m 10 -o /dev/null -s -w %{http_code} 'http://127.0.0.1:2379/v2/keys')
+if [ $code -eq 404 ]; then
+    echo "failed: Please make sure that you have enabled the v2 protocol of etcd."
+    exit 1
+fi
+
+echo "passed: the user has enabled etcd v2 protocol."
+
 # check whether the 'reuseport' is in nginx.conf .
 make init
 
@@ -115,4 +125,4 @@ fi
 
 set -ex
 
-echo "rollback to the default admin config"
+echo "passed: rollback to the default admin config"

--- a/.travis/apisix_cli_test.sh
+++ b/.travis/apisix_cli_test.sh
@@ -23,16 +23,6 @@
 
 set -ex
 
-# check if the user has enabled etcd v2 protocol.
-
-code=$(curl -i -m 10 -o /dev/null -s -w %{http_code} 'http://127.0.0.1:2379/v2/keys')
-if [ $code -eq 404 ]; then
-    echo "failed: Please make sure that you have enabled the v2 protocol of etcd."
-    exit 1
-fi
-
-echo "passed: the user has enabled etcd v2 protocol."
-
 # check whether the 'reuseport' is in nginx.conf .
 make init
 

--- a/bin/apisix
+++ b/bin/apisix
@@ -787,7 +787,8 @@ local function init_etcd(show_output)
         local cmd = "curl -i -m ".. timeout * 2 .. " -o /dev/null -s -w %{http_code} " .. uri
         local res = excute_cmd(cmd)
         if res == "404" then
-            error("failed: Please make sure that you have enabled the v2 protocol of etcd on " .. host)
+            io.stderr:write(string.format("failed: please make sure that you have enabled the v2 protocol of etcd on %s.\n", host))
+        	return
         end
     end
 

--- a/bin/apisix
+++ b/bin/apisix
@@ -788,7 +788,7 @@ local function init_etcd(show_output)
         local res = excute_cmd(cmd)
         if res == "404" then
             io.stderr:write(string.format("failed: please make sure that you have enabled the v2 protocol of etcd on %s.\n", host))
-        	return
+            return
         end
     end
 

--- a/bin/apisix
+++ b/bin/apisix
@@ -781,6 +781,17 @@ local function init_etcd(show_output)
 
     local host_count = #(yaml_conf.etcd.host)
 
+    -- check whether the user has enabled etcd v2 protocol
+    for index, host in ipairs(yaml_conf.etcd.host) do
+        uri = host .. "/v2/keys"
+        local cmd = "curl -i -m ".. timeout * 2 .. " -o /dev/null -s -w %{http_code} " .. uri
+        local res = excute_cmd(cmd)
+        if res == "404" then
+            print("failed: Please make sure that you have enabled the v2 protocol of etcd on " .. host)
+            return
+        end
+    end
+
     local etcd_ok = false
     for index, host in ipairs(yaml_conf.etcd.host) do
 

--- a/bin/apisix
+++ b/bin/apisix
@@ -787,8 +787,7 @@ local function init_etcd(show_output)
         local cmd = "curl -i -m ".. timeout * 2 .. " -o /dev/null -s -w %{http_code} " .. uri
         local res = excute_cmd(cmd)
         if res == "404" then
-            print("failed: Please make sure that you have enabled the v2 protocol of etcd on " .. host)
-            return
+            error("failed: Please make sure that you have enabled the v2 protocol of etcd on " .. host)
         end
     end
 


### PR DESCRIPTION
### Summary

check whether  the user has enabled etcd v2 protocol.

### Full changelog

update the apisix_cli_test.sh to provide a friendly error message when  etvd v2 not enabled.
### Issues resolved

Fix #1523 
