### PR TITLE
fix bug: Execute command 'make run' multiple times, will start multiple processes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ ifeq ("$(wildcard logs/nginx.pid)", "")
 	mkdir -p /tmp/apisix_cores/
 	$(OR_EXEC) -p $$PWD/ -c $$PWD/conf/nginx.conf
 else
-	@echo "Moat is running..."
+	@echo "APISIX is running..."
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -79,9 +79,13 @@ init: default
 ### run:              Start the apisix server
 .PHONY: run
 run: default
+ifeq ("$(wildcard logs/nginx.pid)", "")
 	mkdir -p logs
 	mkdir -p /tmp/apisix_cores/
 	$(OR_EXEC) -p $$PWD/ -c $$PWD/conf/nginx.conf
+else
+	@echo "Moat is running..."
+endif
 
 
 ### stop:             Stop the apisix server


### PR DESCRIPTION
### Execute command 'make run' multiple times, will start multiple processes

重复执行 make run 会启动多个master进程，而 make stop 只能停止一个。

原理：make stop 读取nginx.pid 获取master process id，make stop 后删除 nginx.pid。其他被启动的实例由于缺失nginx.pid文件，读取不到master process id，make stop 失败

### Full changelog

* Makefile 中 make run 章节，校验logs/nginx.pid文件是否存在，存在则不再启动nginx实例

### Issues resolved

Fix #1690
