### PR TITLE
bugfix: the id can be string object, which contains `^[a-zA-Z0-9-_]+$`.

### DIFF
--- a/apisix/admin/global_rules.lua
+++ b/apisix/admin/global_rules.lua
@@ -43,6 +43,8 @@ local function check_conf(id, conf, need_id)
         return nil, {error_msg = "wrong route id"}
     end
 
+    conf.id = id
+
     core.log.info("schema: ", core.json.delay_encode(core.schema.global_rule))
     core.log.info("conf  : ", core.json.delay_encode(conf))
     local ok, err = core.schema.check(core.schema.global_rule, conf)

--- a/apisix/admin/routes.lua
+++ b/apisix/admin/routes.lua
@@ -45,6 +45,8 @@ local function check_conf(id, conf, need_id)
         return nil, {error_msg = "wrong route id"}
     end
 
+    conf.id = id
+
     core.log.info("schema: ", core.json.delay_encode(core.schema.route))
     core.log.info("conf  : ", core.json.delay_encode(conf))
     local ok, err = core.schema.check(core.schema.route, conf)

--- a/apisix/admin/services.lua
+++ b/apisix/admin/services.lua
@@ -20,7 +20,6 @@ local schema_plugin = require("apisix.admin.plugins").check_schema
 local upstreams = require("apisix.admin.upstreams")
 local tostring = tostring
 local ipairs = ipairs
-local tonumber = tonumber
 local type = type
 
 
@@ -47,6 +46,7 @@ local function check_conf(id, conf, need_id)
         return nil, {error_msg = "wrong service id"}
     end
 
+    conf.id = id
 
     core.log.info("schema: ", core.json.delay_encode(core.schema.service))
     core.log.info("conf  : ", core.json.delay_encode(conf))
@@ -55,7 +55,7 @@ local function check_conf(id, conf, need_id)
         return nil, {error_msg = "invalid configuration: " .. err}
     end
 
-    if need_id and not tonumber(id) then
+    if need_id and not id then
         return nil, {error_msg = "wrong type of service id"}
     end
 

--- a/apisix/admin/ssl.lua
+++ b/apisix/admin/ssl.lua
@@ -15,7 +15,6 @@
 -- limitations under the License.
 --
 local core              = require("apisix.core")
-local schema_plugin     = require("apisix.admin.plugins").check_schema
 local tostring          = tostring
 local aes               = require "resty.aes"
 local ngx_encode_base64 = ngx.encode_base64

--- a/apisix/admin/ssl.lua
+++ b/apisix/admin/ssl.lua
@@ -46,52 +46,13 @@ local function check_conf(id, conf, need_id)
         return nil, {error_msg = "wrong ssl id"}
     end
 
+    conf.id = id
+
     core.log.info("schema: ", core.json.delay_encode(core.schema.ssl))
     core.log.info("conf  : ", core.json.delay_encode(conf))
     local ok, err = core.schema.check(core.schema.ssl, conf)
     if not ok then
         return nil, {error_msg = "invalid configuration: " .. err}
-    end
-
-    local upstream_id = conf.upstream_id
-    if upstream_id then
-        local key = "/upstreams/" .. upstream_id
-        local res, err = core.etcd.get(key)
-        if not res then
-            return nil, {error_msg = "failed to fetch upstream info by "
-                                     .. "upstream id [" .. upstream_id .. "]: "
-                                     .. err}
-        end
-
-        if res.status ~= 200 then
-            return nil, {error_msg = "failed to fetch upstream info by "
-                                     .. "upstream id [" .. upstream_id .. "], "
-                                     .. "response code: " .. res.status}
-        end
-    end
-
-    local service_id = conf.service_id
-    if service_id then
-        local key = "/services/" .. service_id
-        local res, err = core.etcd.get(key)
-        if not res then
-            return nil, {error_msg = "failed to fetch service info by "
-                                     .. "service id [" .. service_id .. "]: "
-                                     .. err}
-        end
-
-        if res.status ~= 200 then
-            return nil, {error_msg = "failed to fetch service info by "
-                                     .. "service id [" .. service_id .. "], "
-                                     .. "response code: " .. res.status}
-        end
-    end
-
-    if conf.plugins then
-        local ok, err = schema_plugin(conf.plugins)
-        if not ok then
-            return nil, {error_msg = err}
-        end
     end
 
     return need_id and id or true

--- a/apisix/admin/stream_routes.lua
+++ b/apisix/admin/stream_routes.lua
@@ -31,16 +31,18 @@ local function check_conf(id, conf, need_id)
 
     id = id or conf.id
     if need_id and not id then
-        return nil, {error_msg = "missing stream stream route id"}
+        return nil, {error_msg = "missing stream route id"}
     end
 
     if not need_id and id then
-        return nil, {error_msg = "wrong stream stream route id, do not need it"}
+        return nil, {error_msg = "wrong stream route id, do not need it"}
     end
 
     if need_id and conf.id and tostring(conf.id) ~= tostring(id) then
-        return nil, {error_msg = "wrong stream stream route id"}
+        return nil, {error_msg = "wrong stream route id"}
     end
+
+    conf.id = id
 
     core.log.info("schema: ", core.json.delay_encode(core.schema.stream_route))
     core.log.info("conf  : ", core.json.delay_encode(conf))
@@ -129,7 +131,7 @@ end
 
 function _M.delete(id)
     if not id then
-        return 400, {error_msg = "missing stream stream route id"}
+        return 400, {error_msg = "missing stream route id"}
     end
 
     local key = "/stream_routes/" .. id

--- a/apisix/admin/upstreams.lua
+++ b/apisix/admin/upstreams.lua
@@ -100,9 +100,7 @@ local function check_conf(id, conf, need_id)
     end
 
     -- let schema check id
-    if id and not conf.id then
-        conf.id = id
-    end
+    conf.id = id
 
     core.log.info("schema: ", core.json.delay_encode(core.schema.upstream))
     core.log.info("conf  : ", core.json.delay_encode(conf))

--- a/apisix/schema_def.lua
+++ b/apisix/schema_def.lua
@@ -481,6 +481,7 @@ _M.upstream = upstream_schema
 _M.ssl = {
     type = "object",
     properties = {
+        id = id_schema,
         cert = {
             type = "string", minLength = 128, maxLength = 64*1024
         },
@@ -533,6 +534,7 @@ _M.proto = {
 _M.global_rule = {
     type = "object",
     properties = {
+        id = id_schema,
         plugins = plugins_schema
     },
     required = {"plugins"},
@@ -543,6 +545,7 @@ _M.global_rule = {
 _M.stream_route = {
     type = "object",
     properties = {
+        id = id_schema,
         remote_addr = remote_addr_def,
         server_addr = {
             description = "server IP",

--- a/t/admin/global-rules.t
+++ b/t/admin/global-rules.t
@@ -342,3 +342,26 @@ GET /t
 passed
 --- no_error_log
 [error]
+
+
+
+=== TEST 10: string id(DELETE)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/global_rules/a-b-c-ABC_0123',
+                ngx.HTTP_DELETE
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]

--- a/t/admin/global-rules.t
+++ b/t/admin/global-rules.t
@@ -309,3 +309,36 @@ GET /t
 {"error_msg":"invalid configuration: property \"plugins\" is required"}
 --- no_error_log
 [error]
+
+
+
+=== TEST 9: string id
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/global_rules/a-b-c-ABC_0123',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "limit-count": {
+                            "count": 2,
+                            "time_window": 60,
+                            "rejected_code": 503,
+                            "key": "remote_addr"
+                        }
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]

--- a/t/admin/routes.t
+++ b/t/admin/routes.t
@@ -1807,7 +1807,30 @@ passed
 
 
 
-=== TEST 49: invalid string id
+=== TEST 49: string id(delete)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/a-b-c-ABC_0123',
+                ngx.HTTP_DELETE
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 50: invalid string id
 --- config
     location /t {
         content_by_lua_block {

--- a/t/admin/routes.t
+++ b/t/admin/routes.t
@@ -1772,3 +1772,66 @@ GET /t
 passed
 --- no_error_log
 [error]
+
+
+
+=== TEST 48: string id
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/a-b-c-ABC_0123',
+                ngx.HTTP_PUT,
+                [[{
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:8080": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/index.html"
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 49: invalid string id
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/*invalid',
+                ngx.HTTP_PUT,
+                [[{
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:8080": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/index.html"
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- error_code: 400
+--- no_error_log
+[error]

--- a/t/admin/services.t
+++ b/t/admin/services.t
@@ -928,3 +928,34 @@ GET /t
 passed
 --- no_error_log
 [error]
+
+
+
+=== TEST 27: invalid string id
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/services/*invalid',
+                ngx.HTTP_PUT,
+                [[{
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:8080": 1
+                        },
+                        "type": "roundrobin"
+                    }
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- error_code: 400
+--- no_error_log
+[error]

--- a/t/admin/ssl.t
+++ b/t/admin/ssl.t
@@ -353,3 +353,62 @@ GET /t
 passed
 --- no_error_log
 [error]
+
+
+
+=== TEST 10: string id
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local t = require("lib.test_admin")
+
+            local ssl_cert = t.read_file("conf/cert/apisix.crt")
+            local ssl_key =  t.read_file("conf/cert/apisix.key")
+            local data = {cert = ssl_cert, key = ssl_key, sni = "test.com"}
+
+            local code, body = t.test('/apisix/admin/ssl/a-b-c-ABC_0123',
+                ngx.HTTP_PUT,
+                core.json.encode(data)
+            )
+            if code > 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 11: invalid id
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local t = require("lib.test_admin")
+
+            local ssl_cert = t.read_file("conf/cert/apisix.crt")
+            local ssl_key =  t.read_file("conf/cert/apisix.key")
+            local data = {cert = ssl_cert, key = ssl_key, sni = "test.com"}
+
+            local code, body = t.test('/apisix/admin/ssl/*invalid',
+                ngx.HTTP_PUT,
+                core.json.encode(data)
+            )
+            if code > 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- error_code: 400
+--- no_error_log
+[error]

--- a/t/admin/ssl.t
+++ b/t/admin/ssl.t
@@ -386,7 +386,36 @@ passed
 
 
 
-=== TEST 11: invalid id
+=== TEST 11: string id(delete)
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local t = require("lib.test_admin")
+
+            local ssl_cert = t.read_file("conf/cert/apisix.crt")
+            local ssl_key =  t.read_file("conf/cert/apisix.key")
+            local data = {cert = ssl_cert, key = ssl_key, sni = "test.com"}
+
+            local code, body = t.test('/apisix/admin/ssl/a-b-c-ABC_0123',
+                ngx.HTTP_DELETE
+            )
+            if code > 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 12: invalid id
 --- config
     location /t {
         content_by_lua_block {

--- a/t/admin/stream-routes.t
+++ b/t/admin/stream-routes.t
@@ -297,3 +297,66 @@ GET /t
 [delete] code: 200 message: passed
 --- no_error_log
 [error]
+
+
+
+=== TEST 8: string id
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/stream_routes/a-b-c-ABC_0123',
+                ngx.HTTP_PUT,
+                [[{
+                    "remote_addr": "127.0.0.1",
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:8080": 1
+                        },
+                        "type": "roundrobin"
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 9: invalid string id
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/stream_routes/*invalid',
+                ngx.HTTP_PUT,
+                [[{
+                    "remote_addr": "127.0.0.1",
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:8080": 1
+                        },
+                        "type": "roundrobin"
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- error_code: 400
+--- no_error_log
+[error]

--- a/t/admin/stream-routes.t
+++ b/t/admin/stream-routes.t
@@ -332,7 +332,30 @@ passed
 
 
 
-=== TEST 9: invalid string id
+=== TEST 9: string id(delete)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/stream_routes/a-b-c-ABC_0123',
+                ngx.HTTP_DELETE
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 10: invalid string id
 --- config
     location /t {
         content_by_lua_block {

--- a/t/admin/upstream.t
+++ b/t/admin/upstream.t
@@ -780,7 +780,7 @@ passed
                         "127.0.0.1:8081": 3,
                         "127.0.0.1:8082": 0
                     }
-                }]],                
+                }]],
                 [[{
                     "node": {
                         "value": {
@@ -1277,5 +1277,64 @@ GET /t
 GET /t
 --- response_body
 passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 39: string id
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/upstreams/a-b-c-ABC_0123',
+                ngx.HTTP_PUT,
+                [[{
+                    "nodes": {
+                        "127.0.0.1:8080": 1
+                    },
+                    "type": "roundrobin"
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 40: invalid string id
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/upstreams/*invalid',
+                ngx.HTTP_PUT,
+                [[{
+                    "nodes": {
+                        "127.0.0.1:8080": 1
+                    },
+                    "type": "roundrobin"
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.print(body)
+        }
+    }
+--- request
+GET /t
+--- error_code: 400
+--- response_body
+{"error_msg":"invalid configuration: property \"id\" validation failed: object matches none of the requireds"}
 --- no_error_log
 [error]

--- a/t/admin/upstream.t
+++ b/t/admin/upstream.t
@@ -1311,7 +1311,30 @@ passed
 
 
 
-=== TEST 40: invalid string id
+=== TEST 40: string id(delete)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/upstreams/a-b-c-ABC_0123',
+                ngx.HTTP_DELETE
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 41: invalid string id
 --- config
     location /t {
         content_by_lua_block {


### PR DESCRIPTION
Use uniform id rules for `global rules`, `routes`, `service`, `upstream`, `stream_routes`. 
And use `jsonschema` to check it.