### PR TITLE
test: sleep more time for expiring.

### DIFF
--- a/t/core/lrucache.t
+++ b/t/core/lrucache.t
@@ -258,7 +258,7 @@ obj: {"idx":2,"_cache_ver":"ver"}
             end
 
             local lru_get = core.lrucache.new({
-                ttl = 0.1, count = 256, invalid_stale = true,
+                ttl = 1, count = 256, invalid_stale = true,
             })
 
             local function f()


### PR DESCRIPTION
t/core/lrucache.t test 6 is fail sometimes.

set a longer ttl time to avoid the cache item expired before to fetch.