### PR TITLE
plugin(heartbeat): use `info` log level when failed to report heartbeat.

### DIFF
--- a/apisix/plugins/heartbeat.lua
+++ b/apisix/plugins/heartbeat.lua
@@ -114,7 +114,7 @@ local function report()
     local res
     res, err = request_apisix_svr(args)
     if not res then
-        core.log.error("failed to report heartbeat information: ", err)
+        core.log.info("failed to report heartbeat information: ", err)
         return
     end
 


### PR DESCRIPTION
fixed https://github.com/apache/incubator-apisix/issues/1656