### PR TITLE
optimize: Use lru to avoid resolving IP addresses repeatedly .

### DIFF
--- a/apisix/balancer.lua
+++ b/apisix/balancer.lua
@@ -163,7 +163,7 @@ local function pick_server(route, ctx)
         up_conf.nodes = discovery.nodes(up_conf.service_name)
     end
 
-    local nodes_count = #up_conf.nodes
+    local nodes_count = up_conf.nodes and #up_conf.nodes or 0
     if nodes_count == 0 then
         return nil, "no valid upstream node"
     end
@@ -249,16 +249,16 @@ _M.pick_server = pick_server
 
 
 function _M.run(route, ctx)
-    local res, err = pick_server(route, ctx)
-    if err then
+    local server, err = pick_server(route, ctx)
+    if not server then
         core.log.error("failed to pick server: ", err)
         return core.response.exit(502)
     end
 
-    local ok, err = balancer.set_current_peer(res.host, res.port)
+    local ok, err = balancer.set_current_peer(server.host, server.port)
     if not ok then
-        core.log.error("failed to set server peer [", res.host, ":", res.port,
-                       "] err: ", err)
+        core.log.error("failed to set server peer [", server.host, ":",
+                       server.port, "] err: ", err)
         return core.response.exit(502)
     end
 

--- a/apisix/balancer.lua
+++ b/apisix/balancer.lua
@@ -180,7 +180,10 @@ local function pick_server(route, ctx)
     end
 
     if #up_conf.nodes == 1 then
-        return up_conf.nodes[1]
+        local node = up_conf.nodes[1]
+        ctx.balancer_ip = node.host
+        ctx.balancer_port = node.port
+        return node
     end
 
     local checker = fetch_healthchecker(up_conf, healthcheck_parent, version)

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -262,6 +262,8 @@ function _M.http_access_phase()
         api_ctx.conf_type = nil
         api_ctx.conf_version = nil
         api_ctx.conf_id = nil
+
+        api_ctx.global_rules = router.global_rules
     end
 
     router.router_http.match(api_ctx)
@@ -439,11 +441,9 @@ local function common_phase(plugin_name)
         return
     end
 
-    if router.global_rules and router.global_rules.values
-            and #router.global_rules.values > 0
-    then
+    if api_ctx.global_rules then
         local plugins = core.tablepool.fetch("plugins", 32, 0)
-        local values = router.global_rules.values
+        local values = api_ctx.global_rules.values
         for _, global_rule in config_util.iterate_values(values) do
             core.table.clear(plugins)
             plugins = plugin.filter(global_rule, plugins)

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -112,7 +112,7 @@ local function run_plugin(phase, plugins, api_ctx)
     end
 
     plugins = plugins or api_ctx.plugins
-    if not plugins then
+    if not plugins or #plugins == 0 then
         return api_ctx
     end
 
@@ -435,7 +435,7 @@ function _M.grpc_access_phase()
 end
 
 
-local function common_phase(plugin_name)
+local function common_phase(phase_name)
     local api_ctx = ngx.ctx.api_ctx
     if not api_ctx then
         return
@@ -447,11 +447,12 @@ local function common_phase(plugin_name)
         for _, global_rule in config_util.iterate_values(values) do
             core.table.clear(plugins)
             plugins = plugin.filter(global_rule, plugins)
-            run_plugin(plugin_name, plugins, api_ctx)
+            run_plugin(phase_name, plugins, api_ctx)
         end
         core.tablepool.release("plugins", plugins)
     end
-    run_plugin(plugin_name, nil, api_ctx)
+
+    run_plugin(phase_name, nil, api_ctx)
     return api_ctx
 end
 

--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -235,7 +235,8 @@ end
 function _M.filter(user_route, plugins)
     plugins = plugins or core.table.new(#local_plugins * 2, 0)
     local user_plugin_conf = user_route.value.plugins
-    if user_plugin_conf == nil then
+    if user_plugin_conf == nil or
+       core.table.nkeys(user_plugin_conf) == 0 then
         if local_conf and local_conf.apisix.enable_debug then
             core.response.set_header("Apisix-Plugins", "no plugin")
         end

--- a/benchmark/fake-apisix/conf/nginx.conf
+++ b/benchmark/fake-apisix/conf/nginx.conf
@@ -24,7 +24,6 @@ pid logs/nginx.pid;
 worker_rlimit_nofile 20480;
 
 events {
-    accept_mutex off;
     worker_connections 10620;
 }
 
@@ -32,6 +31,9 @@ worker_shutdown_timeout 3;
 
 http {
     lua_package_path  "$prefix/lua/?.lua;;";
+
+    log_format main '$remote_addr - $remote_user [$time_local] $http_host "$request" $status $body_bytes_sent $request_time "$http_referer" "$http_user_agent" $upstream_addr $upstream_status $upstream_response_time';
+    access_log logs/access.log main buffer=16384 flush=5;
 
     init_by_lua_block {
         require "resty.core"
@@ -59,8 +61,6 @@ http {
         ssl_session_cache    shared:SSL:1m;
 
         listen 9080;
-
-        access_log off;
 
         server_tokens off;
         more_set_headers 'Server: APISIX web server';
@@ -104,6 +104,10 @@ http {
 
             header_filter_by_lua_block {
                 apisix.http_header_filter_phase()
+            }
+
+            body_filter_by_lua_block {
+                apisix.http_body_filter_phase()
             }
 
             log_by_lua_block {

--- a/benchmark/fake-apisix/lua/apisix.lua
+++ b/benchmark/fake-apisix/lua/apisix.lua
@@ -42,6 +42,12 @@ function _M.http_header_filter_phase()
     end
 end
 
+function _M.http_body_filter_phase()
+    if ngx.ctx then
+        -- do something
+    end
+end
+
 function _M.http_log_phase()
     if ngx.ctx then
         -- do something

--- a/benchmark/fake-apisix/lua/apisix.lua
+++ b/benchmark/fake-apisix/lua/apisix.lua
@@ -25,7 +25,7 @@ end
 
 local function fake_fetch()
     ngx.ctx.ip = "127.0.0.1"
-    ngx.ctx.port = 80
+    ngx.ctx.port = 1980
 end
 
 function _M.http_access_phase()

--- a/bin/apisix
+++ b/bin/apisix
@@ -229,7 +229,7 @@ http {
 
     log_format main '$remote_addr - $remote_user [$time_local] $http_host "$request" $status $body_bytes_sent $request_time "$http_referer" "$http_user_agent" $upstream_addr $upstream_status $upstream_response_time';
 
-    access_log {* http.access_log *} main buffer=16384 flush=1;
+    access_log {* http.access_log *} main buffer=16384 flush=3;
     open_file_cache  max=1000 inactive=60;
     client_max_body_size 0;
     keepalive_timeout {* http.keepalive_timeout *};

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -121,7 +121,7 @@ etcd:
   host:                           # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
     - "http://127.0.0.1:2379"     # multiple etcd address
   prefix: "/apisix"               # apisix configurations prefix
-  timeout: 3                      # 3 seconds
+  timeout: 30                     # 3 seconds
   # user: root                     # root username for etcd
   # password: 5tHkHhYkjr6cQY        # root password for etcd
 #eureka:


### PR DESCRIPTION
Cached the global rules to `ctx` .

I got some information from here:

https://gist.github.com/membphis/137db97a4bf64d3653aa42f3e016bd01?notification_referrer_id=MDE4Ok5vdGlmaWNhdGlvblRocmVhZDY4NDQ5Nzk5OTo2ODE0NjA2&notifications_query=reason%3Aparticipating#gistcomment-3353102
