### PR TITLE
remove authentication type for cors plugin

### DIFF
--- a/apisix/plugins/cors.lua
+++ b/apisix/plugins/cors.lua
@@ -71,7 +71,6 @@ local schema = {
 local _M = {
     version = 0.1,
     priority = 4000,
-    type = 'auth',
     name = plugin_name,
     schema = schema,
 }


### PR DESCRIPTION
### Summary

Removes the 'auth' type for the cors plugin

### Full changelog

* removed the 'auth' line

### Issues resolved

Fix #1787
