### PR TITLE
doc: Add guides for installing dependencies on Fedora

### DIFF
--- a/doc/install-dependencies.md
+++ b/doc/install-dependencies.md
@@ -20,6 +20,7 @@
 # Install Dependencies
 - [CentOS 6](#centos-6)
 - [CentOS 7](#centos-7)
+- [Fedora 31 & 32](#fedora-31--32)
 - [Ubuntu 16.04 & 18.04](#ubuntu-1604--1804)
 - [Debian 9 & 10](#debian-9--10)
 - [Mac OSX](#mac-osx)
@@ -63,6 +64,21 @@ sudo yum install -y etcd openresty curl git gcc luarocks lua-devel
 
 # start etcd server
 sudo service etcd start
+```
+
+Fedora 31 & 32
+==============
+
+```shell
+# add OpenResty source
+sudo yum install yum-utils
+sudo yum-config-manager --add-repo https://openresty.org/package/fedora/openresty.repo
+
+# install OpenResty, etcd and some compilation tools
+sudo yum install -y etcd openresty curl git gcc luarocks lua-devel
+
+# start etcd server
+sudo etcd --enable-v2=true &
 ```
 
 Ubuntu 16.04 & 18.04

--- a/doc/zh-cn/install-dependencies.md
+++ b/doc/zh-cn/install-dependencies.md
@@ -20,10 +20,11 @@
 # 安装依赖
 - [CentOS 6](#centos-6)
 - [CentOS 7](#centos-7)
+- [Fedora 31 & 32](#fedora-31--32)
 - [Ubuntu 16.04 & 18.04](#ubuntu-1604--1804)
 - [Debian 9 & 10](#debian-9--10)
 - [Mac OSX](#mac-osx)
-- [如何编译 Openresty](#如何编译-Openresty)
+- [如何编译 Openresty](#如何编译-openresty)
 - [注意](#注意)
 
 CentOS 6
@@ -63,6 +64,21 @@ sudo yum install -y etcd openresty curl git gcc luarocks lua-devel
 
 # 开启 etcd server
 sudo service etcd start
+```
+
+Fedora 31 & 32
+==============
+
+```shell
+# add OpenResty source
+sudo yum install yum-utils
+sudo yum-config-manager --add-repo https://openresty.org/package/fedora/openresty.repo
+
+# install OpenResty, etcd and some compilation tools
+sudo yum install -y etcd openresty curl git gcc luarocks lua-devel
+
+# start etcd server
+sudo etcd --enable-v2=true &
 ```
 
 Ubuntu 16.04 & 18.04


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>

### Summary

For now, the guide for Fedora users is missing in `Install Dependencies` doc. This PR is going to fix that.

### Full changelog

* Add guides for Fedora users in both English and Chinese
* Fix a typo on anchor link.  *I would prefer to add this in this PR instead of a new one.

Thanks.

