### PR TITLE
fix: replace `location /robots.txt ` with `location =/robots.txt `

### DIFF
--- a/bin/apisix
+++ b/bin/apisix
@@ -326,7 +326,7 @@ http {
             try_files $uri $uri/index.html /index.html =404;
         }
 
-        location /robots.txt {
+        location =/robots.txt {
             return 200 'User-agent: *\nDisallow: /';
         }
     }


### PR DESCRIPTION


fix: replace `location /robots.txt ` with `location =/robots.txt ` for admin page