### PR TITLE
add etcd comment for k8s readme. add service-monitor yaml for prometh…

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -23,6 +23,27 @@ There are some yaml files for deploying apisix in Kubernetes.
 ### Prerequisites
 - Install etcd
 
+#### when using etcd-operator
+when using etcd-operator, you need to change apisix-gw-config-cm.yaml:
+
+* add CoreDNS IP into dns_resolver
+
+```
+dns_resolver:
+  - 10.233.0.3      # default coreDNS cluster ip
+
+```
+* change etcd host
+
+Following {your-namespace} should be changed to your namespace, for example `default`.
+> Mention: must use `Full Qualified Domain Name`. Short name `etcd-cluster-client` is not work.
+
+```
+etcd:
+  host:
+    - "http://etcd-cluster-client.{your-namespace}.svc.cluster.local:2379"     # multiple etcd address
+```
+
 ### Usage
 
 #### Create configmap for apache incubator-apisix

--- a/kubernetes/service-monitor-for-prometheus.yaml
+++ b/kubernetes/service-monitor-for-prometheus.yaml
@@ -15,29 +15,25 @@
 # limitations under the License.
 #
 
-apiVersion: v1
-kind: Service
+# when using prometheus-operator, you can apply this into k8s.
+# Mention: ServiceMonitor should be the same namespace with prometheus-operator.
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
 metadata:
-  name: apisix-gw-lb
-  # namespace: default
+  name: apisix-gw
   labels:
-    app: apisix-gw   # useful for service discovery, for example, prometheus-operator.
-spec:
-  ports:
-  - name: http
-    port: 9080
-    protocol: TCP
-    targetPort: 9080
-  - name: https
-    port: 9443
-    protocol: TCP
-    targetPort: 9443
-  # - name: admin-port
-  #   port: 9180
-  #   protocol: TCP
-  #   targetPort: 9180
-  selector:
     app: apisix-gw
-  type: NodePort
-  externalTrafficPolicy: Local
-  # sessionAffinity: None
+spec:
+  endpoints:
+    - interval: 10s
+      honorLabels: true
+      port: http
+      path: /apisix/prometheus/metrics
+      scheme: http
+  selector:
+    matchLabels:
+      app: apisix-gw
+  namespaceSelector:
+    any: true
+


### PR DESCRIPTION

### Summary

1. add comment for etcd operator which is the common way to use etcd in k8s. 
2. add service-monitor yaml which is useful for prometheus-operator.

### Full changelog

* [Improve k8s usability] 


### Issues resolved
No Issue Related.
