### PR TITLE
feature: allow to congfiure the worker_shutdown_timeout

### DIFF
--- a/bin/apisix
+++ b/bin/apisix
@@ -106,7 +106,7 @@ events {
 
 worker_rlimit_core  {* worker_rlimit_core *};
 
-worker_shutdown_timeout 3;
+worker_shutdown_timeout {* worker_shutdown_timeout *};
 
 env APISIX_PROFILE;
 

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -101,6 +101,7 @@ nginx_config:                     # config for render the template to genarate n
   error_log: "logs/error.log"
   error_log_level: "warn"         # warn,error
   worker_rlimit_nofile: 20480     # the number of files a worker process can open, should be larger than worker_connections
+  worker_shutdown_timeout: 3s     # timeout for a graceful shutdown of worker processes
   event:
     worker_connections: 10620
   http:


### PR DESCRIPTION
The default 3s may be too low.