### PR TITLE
bugfix: fetch wrong the upstream node when there were multiple upstream node with host

### DIFF
--- a/apisix/balancer.lua
+++ b/apisix/balancer.lua
@@ -234,7 +234,7 @@ local function pick_server(route, ctx)
     local res, err = lrucache_addr(server, nil, parse_addr, server)
     ctx.balancer_ip = res.host
     ctx.balancer_port = res.port
-    -- core.log.info("proxy to ", host, ":", port)
+    -- core.log.info("cached balancer peer host: ", host, ":", port)
     if err then
         core.log.error("failed to parse server addr: ", server, " err: ", err)
         return core.response.exit(502)
@@ -255,7 +255,7 @@ function _M.run(route, ctx)
         return core.response.exit(502)
     end
 
-    core.log.info("proxy to ", server.host, ":", server.port)
+    core.log.info("proxy request to ", server.host, ":", server.port)
     local ok, err = balancer.set_current_peer(server.host, server.port)
     if not ok then
         core.log.error("failed to set server peer [", server.host, ":",

--- a/apisix/balancer.lua
+++ b/apisix/balancer.lua
@@ -255,6 +255,7 @@ function _M.run(route, ctx)
         return core.response.exit(502)
     end
 
+    core.log.info("proxy to ", server.host, ":", server.port)
     local ok, err = balancer.set_current_peer(server.host, server.port)
     if not ok then
         core.log.error("failed to set server peer [", server.host, ":",

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -166,7 +166,7 @@ end
 local function parse_domain(host)
     local ip_info, err = core.utils.dns_parse(dns_resolver, host)
     if not ip_info then
-        core.log.error("failed to parse domain for ", host, ", error:",err)
+        core.log.error("failed to parse domain: ", host, ", error: ",err)
         return nil, err
     end
 

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -379,6 +379,11 @@ function _M.http_access_phase()
             end
 
             if upstream.has_domain then
+                -- try to fetch the resolved domain, if we got `nil`,
+                -- it means we need to create the cache by handle.
+                -- the `api_ctx.conf_version` is different after we called
+                -- `parse_domain_in_up`, need to recreate the cache by new
+                -- `api_ctx.conf_version`
                 local parsed_upstream, err = resolved_domain(upstream,
                             api_ctx.conf_version, return_direct, nil)
                 if err then

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -392,15 +392,15 @@ function _M.http_access_phase()
                 end
 
                 if not parsed_upstream then
-                    route, err = parse_domain_in_up(upstream, api_ctx)
+                    parsed_upstream, err = parse_domain_in_up(upstream, api_ctx)
                     if err then
                         core.log.error("failed to reolve domain in upstream: ",
                                        err)
                         return core.response.exit(500)
                     end
 
-                    route = resolved_domain(route, api_ctx.conf_version,
-                                        return_direct, route)
+                    resolved_domain(upstream, api_ctx.conf_version,
+                                    return_direct, parsed_upstream)
                 end
 
             end
@@ -426,8 +426,8 @@ function _M.http_access_phase()
                     return core.response.exit(500)
                 end
 
-                route = resolved_domain(route, api_ctx.conf_version,
-                                      return_direct, route)
+                resolved_domain(route, api_ctx.conf_version,
+                                return_direct, route)
             end
         end
 

--- a/apisix/upstream.lua
+++ b/apisix/upstream.lua
@@ -54,6 +54,8 @@ _M.set = set_directly
 
 function _M.set_by_route(route, api_ctx)
     if api_ctx.upstream_conf then
+        core.log.warn("upstream node has been specified, ",
+                      "cannot be set repeatedly")
         return true
     end
 

--- a/t/node/invalid-route.t
+++ b/t/node/invalid-route.t
@@ -157,4 +157,4 @@ passed
 GET /server_port
 --- error_code: 500
 --- error_log
-failed to parse domain in route: server returned error code: 3: name error
+failed to parse domain: xxxx.invalid

--- a/t/node/upstream-domain.t
+++ b/t/node/upstream-domain.t
@@ -160,8 +160,8 @@ GET /t
 status: 500
 status: 500
 --- error_log
-failed to parse domain in upstream: server returned error code
-failed to parse domain in upstream: server returned error code
+failed to parse domain: httpbin.orgx
+failed to parse domain: httpbin.orgx
 --- timeout: 10
 
 

--- a/t/node/upstream-node-dns.t
+++ b/t/node/upstream-node-dns.t
@@ -146,18 +146,18 @@ location /t {
 --- request
 GET /t
 --- grep_error_log eval
-qr/dns resolver domain: test.com to 127.0.0.\d|call \/hello|proxy request to127.0.0.\d:1980/
+qr/dns resolver domain: test.com to 127.0.0.\d|call \/hello|proxy request to 127.0.0.\d:1980/
 --- grep_error_log_out
 call /hello
 dns resolver domain: test.com to 127.0.0.1
-proxy request to127.0.0.1:1980
+proxy request to 127.0.0.1:1980
 call /hello
 dns resolver domain: test.com to 127.0.0.2
-proxy request to127.0.0.2:1980
-proxy request to127.0.0.2:1980
+proxy request to 127.0.0.2:1980
+proxy request to 127.0.0.2:1980
 call /hello
 dns resolver domain: test.com to 127.0.0.3
-proxy request to127.0.0.3:1980
+proxy request to 127.0.0.3:1980
 
 
 
@@ -263,21 +263,21 @@ location /t {
 --- request
 GET /t
 --- grep_error_log eval
-qr/dns resolver domain: \w+.com to 127.0.0.\d|call \/hello|proxy request to127.0.0.\d:1980/
+qr/dns resolver domain: \w+.com to 127.0.0.\d|call \/hello|proxy request to 127.0.0.\d:1980/
 --- grep_error_log_out
 call /hello
 dns resolver domain: test2.com to 127.0.0.1
 dns resolver domain: test.com to 127.0.0.2
-proxy request to127.0.0.1:1980
+proxy request to 127.0.0.1:1980
 call /hello
 dns resolver domain: test2.com to 127.0.0.3
 dns resolver domain: test.com to 127.0.0.4
-proxy request to127.0.0.3:1980
-proxy request to127.0.0.4:1980
+proxy request to 127.0.0.3:1980
+proxy request to 127.0.0.4:1980
 call /hello
 dns resolver domain: test2.com to 127.0.0.5
 dns resolver domain: test.com to 127.0.0.6
-proxy request to127.0.0.5:1980
+proxy request to 127.0.0.5:1980
 
 
 
@@ -380,18 +380,18 @@ location /t {
 --- request
 GET /t
 --- grep_error_log eval
-qr/dns resolver domain: test.com to 127.0.0.\d|call \/hello|proxy request to127.0.0.\d:1980/
+qr/dns resolver domain: test.com to 127.0.0.\d|call \/hello|proxy request to 127.0.0.\d:1980/
 --- grep_error_log_out
 call /hello
 dns resolver domain: test.com to 127.0.0.1
-proxy request to127.0.0.1:1980
+proxy request to 127.0.0.1:1980
 call /hello
 dns resolver domain: test.com to 127.0.0.2
-proxy request to127.0.0.2:1980
-proxy request to127.0.0.2:1980
+proxy request to 127.0.0.2:1980
+proxy request to 127.0.0.2:1980
 call /hello
 dns resolver domain: test.com to 127.0.0.3
-proxy request to127.0.0.3:1980
+proxy request to 127.0.0.3:1980
 
 
 
@@ -469,23 +469,23 @@ location /t {
 --- request
 GET /t
 --- grep_error_log eval
-qr/dns resolver domain: \w+.com to 127.0.0.\d|call \/hello|proxy request to127.0.0.\d:1980/
+qr/dns resolver domain: \w+.com to 127.0.0.\d|call \/hello|proxy request to 127.0.0.\d:1980/
 --- grep_error_log_out
 call /hello
 dns resolver domain: test2.com to 127.0.0.1
 dns resolver domain: test.com to 127.0.0.2
-proxy request to127.0.0.1:1980
+proxy request to 127.0.0.1:1980
 call /hello
 dns resolver domain: test2.com to 127.0.0.3
 dns resolver domain: test.com to 127.0.0.4
-proxy request to127.0.0.3:1980
-proxy request to127.0.0.4:1980
-proxy request to127.0.0.3:1980
-proxy request to127.0.0.4:1980
+proxy request to 127.0.0.3:1980
+proxy request to 127.0.0.4:1980
+proxy request to 127.0.0.3:1980
+proxy request to 127.0.0.4:1980
 call /hello
 dns resolver domain: test2.com to 127.0.0.5
 dns resolver domain: test.com to 127.0.0.6
-proxy request to127.0.0.5:1980
+proxy request to 127.0.0.5:1980
 
 
 
@@ -529,23 +529,23 @@ location /t {
 --- request
 GET /t
 --- grep_error_log eval
-qr/dns resolver domain: \w+.com to 127.0.0.\d|call \/hello|proxy request to127.0.0.\d:1980/
+qr/dns resolver domain: \w+.com to 127.0.0.\d|call \/hello|proxy request to 127.0.0.\d:1980/
 --- grep_error_log_out
 call /hello
 dns resolver domain: test2.com to 127.0.0.1
 dns resolver domain: test.com to 127.0.0.1
-proxy request to127.0.0.1:1980
+proxy request to 127.0.0.1:1980
 call /hello
 dns resolver domain: test2.com to 127.0.0.1
 dns resolver domain: test.com to 127.0.0.1
-proxy request to127.0.0.1:1980
-proxy request to127.0.0.1:1980
-proxy request to127.0.0.1:1980
-proxy request to127.0.0.1:1980
+proxy request to 127.0.0.1:1980
+proxy request to 127.0.0.1:1980
+proxy request to 127.0.0.1:1980
+proxy request to 127.0.0.1:1980
 call /hello
 dns resolver domain: test2.com to 127.0.0.1
 dns resolver domain: test.com to 127.0.0.1
-proxy request to127.0.0.1:1980
+proxy request to 127.0.0.1:1980
 
 
 
@@ -622,17 +622,17 @@ location /t {
 --- request
 GET /t
 --- grep_error_log eval
-qr/dns resolver domain: \w+.com to 127.0.0.\d|call \/hello|proxy request to127.0.0.\d:198\d/
+qr/dns resolver domain: \w+.com to 127.0.0.\d|call \/hello|proxy request to 127.0.0.\d:198\d/
 --- grep_error_log_out
 call /hello
 dns resolver domain: test.com to 127.0.0.1
-proxy request to127.0.0.1:1980
+proxy request to 127.0.0.1:1980
 call /hello
 dns resolver domain: test.com to 127.0.0.2
-proxy request to127.0.0.2:1980
-proxy request to127.0.0.5:1981
-proxy request to127.0.0.2:1980
-proxy request to127.0.0.5:1981
+proxy request to 127.0.0.2:1980
+proxy request to 127.0.0.5:1981
+proxy request to 127.0.0.2:1980
+proxy request to 127.0.0.5:1981
 call /hello
 dns resolver domain: test.com to 127.0.0.3
-proxy request to127.0.0.3:1980
+proxy request to 127.0.0.3:1980

--- a/t/node/upstream-node-dns.t
+++ b/t/node/upstream-node-dns.t
@@ -1,0 +1,160 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+use Cwd qw(cwd);
+
+repeat_each(1);
+log_level('info');
+no_root_location();
+no_shuffle();
+
+my $apisix_home = $ENV{APISIX_HOME} || cwd();
+
+sub read_file($) {
+    my $infile = shift;
+    open my $in, "$apisix_home/$infile"
+        or die "cannot open $infile for reading: $!";
+    my $data = do { local $/; <$in> };
+    close $in;
+    $data;
+}
+
+my $yaml_config = read_file("conf/config.yaml");
+$yaml_config =~ s/node_listen: 9080/node_listen: 1984/;
+$yaml_config =~ s/enable_heartbeat: true/enable_heartbeat: false/;
+$yaml_config =~ s/admin_key:/disable_admin_key:/;
+$yaml_config =~ s/dns_resolver_valid: 30/dns_resolver_valid: 1/;
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    $block->set_value("yaml_config", $yaml_config);
+});
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: set route(id: 1)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "upstream": {
+                        "nodes": {
+                            "test.com:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: hit route, parse upstream node address by DNS
+--- init_by_lua_block
+    require "resty.core"
+    apisix = require("apisix")
+    core = require("apisix.core")
+    apisix.http_init()
+
+    local utils = require("apisix.core.utils")
+    utils.dns_parse = function (resolvers, domain)  -- mock: DNS parser
+        if domain == "test.com" then
+            return {address = "127.0.0.2"}
+        end
+
+        error("unkown domain: " .. domain)
+    end
+--- request
+GET /hello
+--- response_body
+hello world
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: dns cached expired, reparse the domain in upstream node
+--- init_by_lua_block
+    require "resty.core"
+    apisix = require("apisix")
+    core = require("apisix.core")
+    apisix.http_init()
+
+    local utils = require("apisix.core.utils")
+    local count = 0
+    utils.dns_parse = function (resolvers, domain)  -- mock: DNS parser
+        count = count + 1
+
+        if domain == "test.com" then
+            return {address = "127.0.0." .. count}
+        end
+
+        error("unkown domain: " .. domain)
+    end
+
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        core.log.info("call /hello")
+        local code, body = t('/hello', ngx.HTTP_GET)
+
+        ngx.sleep(1.1)  -- cache expired
+        core.log.info("call /hello")
+        local code, body = t('/hello', ngx.HTTP_GET)
+        local code, body = t('/hello', ngx.HTTP_GET)
+
+        ngx.sleep(1.1)  -- cache expired
+        core.log.info("call /hello")
+        local code, body = t('/hello', ngx.HTTP_GET)
+    }
+}
+
+--- request
+GET /t
+--- grep_error_log eval
+qr/dns resolver domain: test.com to 127.0.0.\d|call \/hello|proxy to 127.0.0.\d:1980/
+--- grep_error_log_out
+call /hello
+dns resolver domain: test.com to 127.0.0.1
+proxy to 127.0.0.1:1980
+call /hello
+dns resolver domain: test.com to 127.0.0.2
+proxy to 127.0.0.2:1980
+proxy to 127.0.0.2:1980
+call /hello
+dns resolver domain: test.com to 127.0.0.3
+proxy to 127.0.0.3:1980

--- a/t/node/upstream-node-dns.t
+++ b/t/node/upstream-node-dns.t
@@ -146,18 +146,18 @@ location /t {
 --- request
 GET /t
 --- grep_error_log eval
-qr/dns resolver domain: test.com to 127.0.0.\d|call \/hello|proxy to 127.0.0.\d:1980/
+qr/dns resolver domain: test.com to 127.0.0.\d|call \/hello|proxy request to127.0.0.\d:1980/
 --- grep_error_log_out
 call /hello
 dns resolver domain: test.com to 127.0.0.1
-proxy to 127.0.0.1:1980
+proxy request to127.0.0.1:1980
 call /hello
 dns resolver domain: test.com to 127.0.0.2
-proxy to 127.0.0.2:1980
-proxy to 127.0.0.2:1980
+proxy request to127.0.0.2:1980
+proxy request to127.0.0.2:1980
 call /hello
 dns resolver domain: test.com to 127.0.0.3
-proxy to 127.0.0.3:1980
+proxy request to127.0.0.3:1980
 
 
 
@@ -263,21 +263,21 @@ location /t {
 --- request
 GET /t
 --- grep_error_log eval
-qr/dns resolver domain: \w+.com to 127.0.0.\d|call \/hello|proxy to 127.0.0.\d:1980/
+qr/dns resolver domain: \w+.com to 127.0.0.\d|call \/hello|proxy request to127.0.0.\d:1980/
 --- grep_error_log_out
 call /hello
 dns resolver domain: test2.com to 127.0.0.1
 dns resolver domain: test.com to 127.0.0.2
-proxy to 127.0.0.1:1980
+proxy request to127.0.0.1:1980
 call /hello
 dns resolver domain: test2.com to 127.0.0.3
 dns resolver domain: test.com to 127.0.0.4
-proxy to 127.0.0.3:1980
-proxy to 127.0.0.4:1980
+proxy request to127.0.0.3:1980
+proxy request to127.0.0.4:1980
 call /hello
 dns resolver domain: test2.com to 127.0.0.5
 dns resolver domain: test.com to 127.0.0.6
-proxy to 127.0.0.5:1980
+proxy request to127.0.0.5:1980
 
 
 
@@ -380,18 +380,18 @@ location /t {
 --- request
 GET /t
 --- grep_error_log eval
-qr/dns resolver domain: test.com to 127.0.0.\d|call \/hello|proxy to 127.0.0.\d:1980/
+qr/dns resolver domain: test.com to 127.0.0.\d|call \/hello|proxy request to127.0.0.\d:1980/
 --- grep_error_log_out
 call /hello
 dns resolver domain: test.com to 127.0.0.1
-proxy to 127.0.0.1:1980
+proxy request to127.0.0.1:1980
 call /hello
 dns resolver domain: test.com to 127.0.0.2
-proxy to 127.0.0.2:1980
-proxy to 127.0.0.2:1980
+proxy request to127.0.0.2:1980
+proxy request to127.0.0.2:1980
 call /hello
 dns resolver domain: test.com to 127.0.0.3
-proxy to 127.0.0.3:1980
+proxy request to127.0.0.3:1980
 
 
 
@@ -469,23 +469,23 @@ location /t {
 --- request
 GET /t
 --- grep_error_log eval
-qr/dns resolver domain: \w+.com to 127.0.0.\d|call \/hello|proxy to 127.0.0.\d:1980/
+qr/dns resolver domain: \w+.com to 127.0.0.\d|call \/hello|proxy request to127.0.0.\d:1980/
 --- grep_error_log_out
 call /hello
 dns resolver domain: test2.com to 127.0.0.1
 dns resolver domain: test.com to 127.0.0.2
-proxy to 127.0.0.1:1980
+proxy request to127.0.0.1:1980
 call /hello
 dns resolver domain: test2.com to 127.0.0.3
 dns resolver domain: test.com to 127.0.0.4
-proxy to 127.0.0.3:1980
-proxy to 127.0.0.4:1980
-proxy to 127.0.0.3:1980
-proxy to 127.0.0.4:1980
+proxy request to127.0.0.3:1980
+proxy request to127.0.0.4:1980
+proxy request to127.0.0.3:1980
+proxy request to127.0.0.4:1980
 call /hello
 dns resolver domain: test2.com to 127.0.0.5
 dns resolver domain: test.com to 127.0.0.6
-proxy to 127.0.0.5:1980
+proxy request to127.0.0.5:1980
 
 
 
@@ -529,23 +529,23 @@ location /t {
 --- request
 GET /t
 --- grep_error_log eval
-qr/dns resolver domain: \w+.com to 127.0.0.\d|call \/hello|proxy to 127.0.0.\d:1980/
+qr/dns resolver domain: \w+.com to 127.0.0.\d|call \/hello|proxy request to127.0.0.\d:1980/
 --- grep_error_log_out
 call /hello
 dns resolver domain: test2.com to 127.0.0.1
 dns resolver domain: test.com to 127.0.0.1
-proxy to 127.0.0.1:1980
+proxy request to127.0.0.1:1980
 call /hello
 dns resolver domain: test2.com to 127.0.0.1
 dns resolver domain: test.com to 127.0.0.1
-proxy to 127.0.0.1:1980
-proxy to 127.0.0.1:1980
-proxy to 127.0.0.1:1980
-proxy to 127.0.0.1:1980
+proxy request to127.0.0.1:1980
+proxy request to127.0.0.1:1980
+proxy request to127.0.0.1:1980
+proxy request to127.0.0.1:1980
 call /hello
 dns resolver domain: test2.com to 127.0.0.1
 dns resolver domain: test.com to 127.0.0.1
-proxy to 127.0.0.1:1980
+proxy request to127.0.0.1:1980
 
 
 
@@ -622,17 +622,17 @@ location /t {
 --- request
 GET /t
 --- grep_error_log eval
-qr/dns resolver domain: \w+.com to 127.0.0.\d|call \/hello|proxy to 127.0.0.\d:198\d/
+qr/dns resolver domain: \w+.com to 127.0.0.\d|call \/hello|proxy request to127.0.0.\d:198\d/
 --- grep_error_log_out
 call /hello
 dns resolver domain: test.com to 127.0.0.1
-proxy to 127.0.0.1:1980
+proxy request to127.0.0.1:1980
 call /hello
 dns resolver domain: test.com to 127.0.0.2
-proxy to 127.0.0.2:1980
-proxy to 127.0.0.5:1981
-proxy to 127.0.0.2:1980
-proxy to 127.0.0.5:1981
+proxy request to127.0.0.2:1980
+proxy request to127.0.0.5:1981
+proxy request to127.0.0.2:1980
+proxy request to127.0.0.5:1981
 call /hello
 dns resolver domain: test.com to 127.0.0.3
-proxy to 127.0.0.3:1980
+proxy request to127.0.0.3:1980


### PR DESCRIPTION
> latest message

While adding test cases, two new bugs were found, and those bugs have existed for several months.
And I fixed them in this PR.

> old message

…S and proxy

  the request to the new address.

We have fixed this bug in `master` branch, but we can get if we run this test case in branch `v1.4`. 
Add some test cases to confirm the `master` branch works fine for this case.

```shell
# 1.4 version
t/node/upstream-node-dns.t .. 7/?
#   Failed test 'TEST 3: dns cached expired, reparse the domain in upstream node - grep_error_log_out (req 0)'
#   at /usr/local/share/perl5/5.30/Test/Nginx/Socket.pm line 1088.
# @@ -1,10 +1,14 @@
#  call /hello
#  dns resolver domain: test.com to 127.0.0.1
#  proxy to 127.0.0.1:1980
# +proxy to 127.0.0.1:1980
#  call /hello
#  dns resolver domain: test.com to 127.0.0.2
# -proxy to 127.0.0.2:1980
# -proxy to 127.0.0.2:1980
# +proxy to 127.0.0.1:1980
# +proxy to 127.0.0.1:1980
# +proxy to 127.0.0.1:1980
# +proxy to 127.0.0.1:1980
#  call /hello
#  dns resolver domain: test.com to 127.0.0.3
# -proxy to 127.0.0.3:1980
# +proxy to 127.0.0.1:1980
# +proxy to 127.0.0.1:1980
# Looks like you failed 1 test of 8.
```

Fix https://github.com/apache/incubator-apisix/issues/1834