### PR TITLE
The recommended value for worker_shutdown_timeout is 240 seconds.

### DIFF
--- a/.travis/apisix_cli_test.sh
+++ b/.travis/apisix_cli_test.sh
@@ -149,3 +149,15 @@ fi
 set -ex
 
 echo "passed: rollback to the default admin config"
+
+# check the 'worker_shutdown_timeout' in 'nginx.conf' .
+
+make init
+
+grep -E "worker_shutdown_timeout 240s" conf/nginx.conf > /dev/null
+if [ ! $? -eq 0 ]; then
+    echo "failed: worker_shutdown_timeout in nginx.conf is required 240s"
+    exit 1
+fi
+
+echo "passed: worker_shutdown_timeout in nginx.conf is ok"

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -104,7 +104,7 @@ nginx_config:                     # config for render the template to genarate n
   error_log: "logs/error.log"
   error_log_level: "warn"         # warn,error
   worker_rlimit_nofile: 20480     # the number of files a worker process can open, should be larger than worker_connections
-  worker_shutdown_timeout: 3s     # timeout for a graceful shutdown of worker processes
+  worker_shutdown_timeout: 240s     # timeout for a graceful shutdown of worker processes
   event:
     worker_connections: 10620
   http:


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The recommended value for worker_shutdown_timeout is 240 seconds.
#1853 

### Pre-submission checklist:

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible?
