### PR TITLE
Resolves #1902 Different upstreams use different discovery and customize the discovery schema #1903

### DIFF
--- a/apisix/balancer.lua
+++ b/apisix/balancer.lua
@@ -156,11 +156,16 @@ local function pick_server(route, ctx)
     core.log.info("route: ", core.json.delay_encode(route, true))
     core.log.info("ctx: ", core.json.delay_encode(ctx, true))
     local up_conf = ctx.upstream_conf
-    if up_conf.service_name then
-        if not discovery then
+    if up_conf.type == "discovery" then
+        if not up_conf.discovery_type then
+            return nil, "discovery server need appoint"
+        end
+
+        local dis = discovery[up_conf.discovery_type]
+        if not dis then
             return nil, "discovery is uninitialized"
         end
-        up_conf.nodes = discovery.nodes(up_conf.service_name)
+        up_conf.nodes = dis.nodes(up_conf)
     end
 
     local nodes_count = up_conf.nodes and #up_conf.nodes or 0

--- a/apisix/discovery/etcd.lua
+++ b/apisix/discovery/etcd.lua
@@ -1,0 +1,43 @@
+
+local etcd = require('apisix.core.etcd')
+local ngx_timer_at       = ngx.timer.at
+local ngx_timer_every    = ngx.timer.every
+
+local applications
+local discovery_key = "service_dicovery"
+
+local schema = {
+    type = "object",
+    properties = {
+        service_name = { type = "string", maxLength = 256 }
+    },
+    anyOf = {
+        { require = { 'service_name' }}
+    },
+}
+
+local _M = {
+    version = 0.1,
+    schema = schema,
+}
+
+local function fetch_full_registry(premature)
+
+    if premature then
+        return
+    end
+
+    local res = etcd.get(discovery_key)
+    applications = res.body.node.value
+end
+
+function _M.nodes(up_conf)
+    return { [1] = applications[up_conf.etcd.service_name]}
+end
+
+function _M.init_worker()
+    ngx_timer_at(0, fetch_full_registry)
+    ngx_timer_every(30, fetch_full_registry)
+end
+
+return _M

--- a/apisix/discovery/init.lua
+++ b/apisix/discovery/init.lua
@@ -15,22 +15,26 @@
 -- limitations under the License.
 --
 
-local local_conf   = require("apisix.core.config_local").local_conf()
 
+local local_conf   = require("apisix.core.config_local").local_conf()
 
 local discovery_type = local_conf.apisix.discovery
 local discovery = {
     schema = {}
 }
 
-for i = 1, #(discovery_type) do
-    discovery[discovery_type[i]] = require("apisix.discovery." .. discovery_type[i])
-    discovery.schema[discovery_type[i]] = discovery[discovery_type[i]].schema
+if discovery_type then
+    for i = 1, #(discovery_type) do
+        discovery[discovery_type[i]] = require("apisix.discovery." .. discovery_type[i])
+        discovery.schema[discovery_type[i]] = discovery[discovery_type[i]].schema
+    end
 end
 
 function discovery.init_worker()
-    for i = 1, #(discovery_type) do
-        discovery[discovery_type[i]].init_worker()
+    if discovery_type then
+        for i = 1, #(discovery_type) do
+            discovery[discovery_type[i]].init_worker()
+        end
     end
 end
 

--- a/apisix/discovery/init.lua
+++ b/apisix/discovery/init.lua
@@ -15,17 +15,24 @@
 -- limitations under the License.
 --
 
-local log          = require("apisix.core.log")
 local local_conf   = require("apisix.core.config_local").local_conf()
 
-local discovery_type = local_conf.apisix and local_conf.apisix.discovery
-local discovery
 
-if discovery_type then
-    log.info("use discovery: ", discovery_type)
-    discovery = require("apisix.discovery." .. discovery_type)
+local discovery_type = local_conf.apisix.discovery
+local discovery = {
+    schema = {}
+}
+
+for i = 1, #(discovery_type) do
+    discovery[discovery_type[i]] = require("apisix.discovery." .. discovery_type[i])
+    discovery.schema[discovery_type[i]] = discovery[discovery_type[i]].schema
 end
 
+function discovery.init_worker()
+    for i = 1, #(discovery_type) do
+        discovery[discovery_type[i]].init_worker()
+    end
+end
 
 return {
     version = 0.1,

--- a/apisix/schema_def.lua
+++ b/apisix/schema_def.lua
@@ -14,6 +14,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 --
+local discovery = require('apisix.discovery').discovery
 local schema    = require('apisix.core.schema')
 local setmetatable = setmetatable
 local error     = error

--- a/apisix/schema_def.lua
+++ b/apisix/schema_def.lua
@@ -306,7 +306,7 @@ local upstream_schema = {
         type = {
             description = "algorithms of load balancing",
             type = "string",
-            enum = {"chash", "roundrobin"}
+            enum = {"chash", "roundrobin","discovery"}
         },
         checks = health_checker,
         hash_on = {
@@ -327,6 +327,10 @@ local upstream_schema = {
             description = "enable websocket for request",
             type        = "boolean"
         },
+        discovery_type = {
+            description = "discovery type",
+            type = "string",
+        },
         name = {type = "string", maxLength = 50},
         desc = {type = "string", maxLength = 256},
         service_name = {type = "string", maxLength = 50},
@@ -335,10 +339,14 @@ local upstream_schema = {
     anyOf = {
         {required = {"type", "nodes"}},
         {required = {"type", "k8s_deployment_info"}},
-        {required = {"type", "service_name"}},
+        {required = {"type", "discovery_type"}},
     },
     additionalProperties = false,
 }
+
+for name, v in pairs(discovery.schema) do
+    upstream_schema.properties[name] = v
+end
 
 -- TODO: add more nginx variable support
 _M.upstream_hash_vars_schema = {

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -99,7 +99,8 @@ apisix:
     key_encrypt_salt: "edd1c9f0985e76a2"    #  If not set, will save origin ssl key into etcd.
                                             #  If set this, must be a string of length 16. And it will encrypt ssl key with AES-128-CBC
                                             #  !!! So do not change it after saving your ssl, it can't decrypt the ssl keys have be saved if you change !!
-#  discovery: eureka               # service discovery center
+  # discovery:                # service discovery center(需导入插件代码依赖)
+  #   - etcd
 nginx_config:                     # config for render the template to genarate nginx.conf
   error_log: "logs/error.log"
   error_log_level: "warn"         # warn,error


### PR DESCRIPTION
### What this PR does / why we need it:
1. Now discovery can only use one of them at the same time
2. Parameter can only use ‘service_ name’, this does not fit all service discovery

### Pre-submission checklist:
- modify schema_ def.lua to load it into the discovery schema to adapt to the customized parameters of different discovery.
- modify config.yaml Type of file discovery (changed to list)
- modify the balancer.lua to get IP according to the specified discovery
- modify discovery/init.lua, load them in the discovery resgistered in the config.yaml
