### PR TITLE
fix: run `apisix start` several times will start multi nginx processes

### DIFF
--- a/.travis/linux_openresty_runner.sh
+++ b/.travis/linux_openresty_runner.sh
@@ -141,6 +141,13 @@ script() {
     ./bin/apisix init_etcd
     ./bin/apisix start
 
+    #start again
+    res=`./bin/apisix start`
+    if [ "$res" != "APISIX is running..." ]; then
+        echo "failed: APISIX runs repeatedly"
+        exit 1
+    fi
+
     sleep 1
     cat logs/error.log
 

--- a/.travis/linux_openresty_runner.sh
+++ b/.travis/linux_openresty_runner.sh
@@ -149,7 +149,7 @@ script() {
     fi
 
     #kill apisix
-    sudo kill -s 9 `ps aux | grep apisix | awk '{print $2}'`
+    sudo kill -s 9 `ps aux | grep apisix | grep nginx | awk '{print $2}'`
 
     #start -> ok
     res=`./bin/apisix start`

--- a/.travis/linux_openresty_runner.sh
+++ b/.travis/linux_openresty_runner.sh
@@ -153,8 +153,8 @@ script() {
 
     #start -> ok
     res=`./bin/apisix start`
-    if [ "$res" != "APISIX is running..." ]; then
-        echo "failed: APISIX runs repeatedly"
+    if [ "$res" == "APISIX is running..." ]; then
+        echo "failed: shouldn't stop APISIX running after kill the old process."
         exit 1
     fi
 

--- a/.travis/linux_openresty_runner.sh
+++ b/.travis/linux_openresty_runner.sh
@@ -156,7 +156,7 @@ script() {
     if [ "$res" != "APISIX is running..." ]; then
         echo "failed: APISIX runs repeatedly"
         exit 1
-    fi    
+    fi
 
     sleep 1
     cat logs/error.log

--- a/.travis/linux_openresty_runner.sh
+++ b/.travis/linux_openresty_runner.sh
@@ -141,12 +141,22 @@ script() {
     ./bin/apisix init_etcd
     ./bin/apisix start
 
-    #start again
+    #start again  --> fial
     res=`./bin/apisix start`
     if [ "$res" != "APISIX is running..." ]; then
         echo "failed: APISIX runs repeatedly"
         exit 1
     fi
+
+    #kill apisix
+    sudo kill -s 9 `ps aux | grep apisix | awk '{print $2}'`
+
+    #start -> ok
+    res=`./bin/apisix start`
+    if [ "$res" != "APISIX is running..." ]; then
+        echo "failed: APISIX runs repeatedly"
+        exit 1
+    fi    
 
     sleep 1
     cat logs/error.log

--- a/.travis/linux_openresty_runner.sh
+++ b/.travis/linux_openresty_runner.sh
@@ -149,7 +149,7 @@ script() {
     fi
 
     #kill apisix
-    sudo kill -s 9 `ps aux | grep apisix | grep nginx | awk '{print $2}'`
+    sudo kill -9 `ps aux | grep apisix | grep nginx | awk '{print $2}'`
 
     #start -> ok
     res=`./bin/apisix start`

--- a/bin/apisix
+++ b/bin/apisix
@@ -858,8 +858,12 @@ function _M.start(...)
     local pid_path = apisix_home .. "/logs/nginx.pid"
     local pid, err = read_file(pid_path)
     if pid then
-        print("APISIX is running...")
-        return nil
+        local hd = io.popen("lsof -p " .. pid)
+        local res = hd:read("*a")
+        if res and res ~= "" then
+            print("APISIX is running...")
+            return nil
+        end
     end
 
     init(...)
@@ -868,7 +872,6 @@ function _M.start(...)
     local cmd = openresty_args
     -- print(cmd)
     os.execute(cmd)
-
 end
 
 function _M.stop()

--- a/bin/apisix
+++ b/bin/apisix
@@ -854,12 +854,21 @@ local openresty_args = [[openresty  -p ]] .. apisix_home .. [[ -c ]]
                        .. apisix_home .. [[/conf/nginx.conf]]
 
 function _M.start(...)
+    -- check running
+    local pid_path = apisix_home .. "/logs/nginx.pid"
+    local pid, err = read_file(pid_path)
+    if pid then
+        print("APISIX is running...")
+        return nil
+    end
+
     init(...)
     init_etcd(...)
 
     local cmd = openresty_args
     -- print(cmd)
     os.execute(cmd)
+
 end
 
 function _M.stop()
@@ -874,6 +883,9 @@ function _M.restart()
 end
 
 function _M.reload()
+    -- reinit nginx.conf
+    init()
+
     local test_cmd = openresty_args .. [[ -t -q ]]
     -- When success,
     -- On linux, os.execute returns 0,


### PR DESCRIPTION
### What this PR does / why we need it:
Run `apisix start` several times, will start multi nginx processes.when we want to update `conf/config.yaml`, some processes  fail to use the new conf.

#1663 
#1671 

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible?
