### PR TITLE
doc: fixed `uri-blocker` plugin path error in `README`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ A/B testing, canary release, blue-green deployment, limit rate, defense against 
     - [Limit-concurrency](doc/plugins/limit-conn.md)
     - Anti-ReDoS(Regular expression Denial of Service): Built-in policies to Anti ReDoS without configuration.
     - [CORS](doc/plugins/cors.md) Enable CORS(Cross-origin resource sharing) for your API.
-    - [uri-blocker](plugins/uri-blocker.md): Block client request by URI.
+    - [uri-blocker](doc/plugins/uri-blocker.md): Block client request by URI.
 
 - **OPS friendly**
     - OpenTracing: support [Apache Skywalking](doc/plugins/skywalking.md) and [Zipkin](doc/plugins/zipkin.md)

--- a/README_CN.md
+++ b/README_CN.md
@@ -89,7 +89,7 @@ A/B 测试、金丝雀发布(灰度发布)、蓝绿部署、限流限速、抵�
     - [限制并发](doc/zh-cn/plugins/limit-conn.md)
     - 防御 ReDoS(正则表达式拒绝服务)：内置策略，无需配置即可抵御 ReDoS。
     - [CORS](doc/zh-cn/plugins/cors.md)：为你的API启用 CORS。
-    - [uri-blocker](plugins/uri-blocker.md)：根据 URI 拦截用户请求。
+    - [uri-blocker](doc/plugins/uri-blocker.md)：根据 URI 拦截用户请求。
 
 - **运维友好**
     - OpenTracing 可观测性: 支持 [Apache Skywalking](doc/zh-cn/plugins/skywalking.md) 和 [Zipkin](doc/zh-cn/plugins/zipkin.md)。


### PR DESCRIPTION
### What this PR does / why we need it:
FIX #1949 
Currently `uri-blocker` does not have a Chinese document. The address of `README_CN.md` will point to the English document. Next, I will use a new PR to submit the Chinese document.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Is this PR backward compatible?
